### PR TITLE
DBAAS-2476: missing import, print exceptions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ dependencies = [
 ]
 setup(
     name="splicemachine",
-    version="0.4.0",
+    version="0.4.1",
     install_requires=dependencies,
     packages=find_packages(),
     license='Apache License, Version 2.0',

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ dependencies = [
 ]
 setup(
     name="splicemachine",
-    version="0.4.1",
+    version="1.0.0",
     install_requires=dependencies,
     packages=find_packages(),
     license='Apache License, Version 2.0',

--- a/splicemachine/spark/context.py
+++ b/splicemachine/spark/context.py
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 from __future__ import print_function
-
+import os
 from py4j.java_gateway import java_import
 from pyspark.sql import DataFrame
 
@@ -228,7 +228,8 @@ class SpliceMLContext(PySpliceContext):
         try:
             url = os.environ['JDBC_URL']
             PySpliceContext.__init__(self, url, sparkSession, _unit_testing)
-        except:
+        except Exception as e:
+            print(e)
             print('The SpliceMLContext is only for use on the cloud service. Please import and use the PySpliceContext instead.\nUsage:\n\tfrom splicemachine.spark.context import PySpliceContext\n\tsplice = PySpliceContext(jdbc_url, sparkSession)')
             return -1
         if useH2O:


### PR DESCRIPTION
This works in QA for the issue we were seeing. Murray replaced the running code in zeppelin with these changes and tested it out.