### PR TITLE
Dbaas 4521

### DIFF
--- a/splicemachine/mlflow_support/constants.py
+++ b/splicemachine/mlflow_support/constants.py
@@ -18,9 +18,26 @@ class FileExtensions:
         return (
             FileExtensions.spark, FileExtensions.keras, FileExtensions.h2o, FileExtensions.sklearn
         )
+    @staticmethod
+    def map_from_mlflow_flavor(flavor: str):
+        return {
+            'spark': 'spark',
+            'h2o': 'h2o',
+            'keras': 'h5',
+            'sklearn': 'pkl'
+        }[flavor]
 
+class DatabaseSupportedLibs:
+    """
+    Class containing supported model libraries for native database model deployment
+    """
+    @staticmethod
+    def get_valid():
+        return (
+            'spark', 'h2o', 'sklearn', 'keras'
+        )
 
-class ModelStatuses():
+class ModelStatuses:
     """
     Class containing names
     for In Database Model Deployments

--- a/splicemachine/mlflow_support/mlflow_support.py
+++ b/splicemachine/mlflow_support/mlflow_support.py
@@ -676,7 +676,7 @@ def _deploy_azure(endpoint_name: str, resource_group: str, workspace: str, run_i
 @_mlflow_patch('deploy_kubernetes')
 def _deploy_kubernetes(run_id: str, service_port: int = 80,
                        base_replicas: int = 1, autoscaling_enabled: bool = False,
-                       max_replicas: bool = 2, target_cpu_utilization: int = 50,
+                       max_replicas: int = 2, target_cpu_utilization: int = 50,
                        disable_nginx: bool = False, gunicorn_workers: int = 1,
                        resource_requests_enabled: bool = False, resource_limits_enabled: bool = False,
                        cpu_request: int = 0.5, cpu_limit: int = 1, memory_request: str = "512Mi",

--- a/splicemachine/mlflow_support/mlflow_support.py
+++ b/splicemachine/mlflow_support/mlflow_support.py
@@ -251,10 +251,13 @@ def __get_serialized_mlmodel(model, conda_env=None):
             mlflow.set_tag('splice.tf_version', tf_version)
             mlflow.keras.save_model(model, mlmodel_dir, conda_env=conda_env)
             file_ext = FileExtensions.keras
-        else:
-            raise SpliceMachineException('Model type not supported for logging.'
-                                         'Currently we support logging Spark, H2O, SKLearn and Keras (TF backend) models.'
-                                         'You can save your model to disk, zip it and run mlflow.log_artifact to save.')
+        else: # Save as pyfunc
+
+
+        # else:
+        #     raise SpliceMachineException('Model type not supported for logging.'
+        #                                  'Currently we support logging Spark, H2O, SKLearn and Keras (TF backend) models.'
+        #                                  'You can save your model to disk, zip it and run mlflow.log_artifact to save.')
 
         for model_file in glob.glob(mlmodel_dir + "/**/*", recursive=True):
             zip_buffer.write(model_file, arcname=path.relpath(model_file, mlmodel_dir))
@@ -263,13 +266,16 @@ def __get_serialized_mlmodel(model, conda_env=None):
 
 
 @_mlflow_patch('log_model')
-def _log_model(model, name='model', conda_env=None):
+def _log_model(model, name='model', conda_env=None, model_class=None):
     """
     Log a trained machine learning model
 
     :param model: (Model) is the trained Spark/SKlearn/H2O/Keras model
         with the current run
     :param name: (str) the run relative name to store the model under. [Deault 'model']
+    :param conda_env: An optional conda environment for specifying custom configurations
+    :param model_class: An optional param specifying the model type of the model to log
+        Available options match the mlflow built-in model flavors https://www.mlflow.org/docs/1.8.0/models.html#built-in-model-flavors
     """
     _check_for_splice_ctx()
 

--- a/splicemachine/mlflow_support/mlflow_support.py
+++ b/splicemachine/mlflow_support/mlflow_support.py
@@ -241,7 +241,7 @@ def __get_serialized_mlmodel(model, conda_env=None, model_lib=None):
             except:
                 raise SpliceMachineException(f'Failed to save model type {model_lib}. Ensure that is a supposed model '
                                              f'flavor https://www.mlflow.org/docs/1.8.0/models.html#built-in-model-flavors\n'
-                                             f'Or you can build a pyfunc model'
+                                             f'Or you can build a pyfunc model\n'
                                              'https://www.mlflow.org/docs/1.8.0/models.html#python-function-python-function')
         elif isinstance(model, H2OModel):
             import mlflow.h2o
@@ -266,7 +266,7 @@ def __get_serialized_mlmodel(model, conda_env=None, model_lib=None):
             file_ext = FileExtensions.keras
         else:
             raise SpliceMachineException('Model type not supported for logging. If you received this error,'
-                                         'you should pass a value to the model_class parameter of the model type you'
+                                         'you should pass a value to the model_lib parameter of the model type you '
                                          'want to save. Supported values are available here: '
                                          'https://www.mlflow.org/docs/1.8.0/models.html#built-in-model-flavors\n'
                                          'as well as \'pyfunc\' '

--- a/splicemachine/mlflow_support/mlflow_support.py
+++ b/splicemachine/mlflow_support/mlflow_support.py
@@ -233,7 +233,6 @@ def __get_serialized_mlmodel(model, conda_env=None, model_class=None):
             try:
                 import mlflow
                 import_module(f'mlflow.{model_class}')
-                mlflow._splice_context.df()
                 getattr(mlflow, model_class).save_model(tempdir, conda_env=conda_env)
             except:
                 raise SpliceMachineException(f'Failed to save model type {model_class}. Ensure that is a supposed model'

--- a/splicemachine/mlflow_support/mlflow_support.py
+++ b/splicemachine/mlflow_support/mlflow_support.py
@@ -233,9 +233,9 @@ def __get_serialized_mlmodel(model, conda_env=None, model_lib=None):
             try:
                 import mlflow
                 import_module(f'mlflow.{model_lib}')
-                getattr(mlflow, model_lib).save_model(tempdir, conda_env=conda_env)
+                getattr(mlflow, model_lib).save_model(python_model=model, path=mlmodel_dir, conda_env=conda_env)
             except:
-                raise SpliceMachineException(f'Failed to save model type {model_lib}. Ensure that is a supposed model'
+                raise SpliceMachineException(f'Failed to save model type {model_lib}. Ensure that is a supposed model '
                                              f'flavor https://www.mlflow.org/docs/1.8.0/models.html#built-in-model-flavors\n'
                                              f'Or you can build a pyfunc model'
                                              'https://www.mlflow.org/docs/1.8.0/models.html#python-function-python-function')

--- a/splicemachine/mlflow_support/mlflow_support.py
+++ b/splicemachine/mlflow_support/mlflow_support.py
@@ -71,7 +71,7 @@ from tensorflow import __version__ as tf_version
 from tensorflow.keras import Model as KerasModel
 from tensorflow.keras import __version__ as keras_version
 
-from splicemachine.mlflow_support.constants import (FileExtensions)
+from splicemachine.mlflow_support.constants import (FileExtensions, DatabaseSupportedLibs)
 from splicemachine.mlflow_support.utilities import (SparkUtils, SpliceMachineException, get_pod_uri, get_user,
                                                     insert_artifact)
 from splicemachine.spark.context import PySpliceContext
@@ -234,6 +234,10 @@ def __get_serialized_mlmodel(model, conda_env=None, model_lib=None):
                 import mlflow
                 import_module(f'mlflow.{model_lib}')
                 getattr(mlflow, model_lib).save_model(python_model=model, path=mlmodel_dir, conda_env=conda_env)
+
+                file_ext = FileExtensions.map_from_mlflow_flavor(model_lib) if \
+                    model_lib in DatabaseSupportedLibs.get_valid() else model_lib
+
             except:
                 raise SpliceMachineException(f'Failed to save model type {model_lib}. Ensure that is a supposed model '
                                              f'flavor https://www.mlflow.org/docs/1.8.0/models.html#built-in-model-flavors\n'

--- a/splicemachine/mlflow_support/mlflow_support.py
+++ b/splicemachine/mlflow_support/mlflow_support.py
@@ -865,13 +865,11 @@ def _watch_job(job_id: int):
         # searching from the end is faster, because unless the logs double in the interval, it will be closer
         for log_idx in range(len(logs_retrieved) - 1, -1, -1):
             if logs_retrieved[log_idx] in previous_lines:
-                if log_idx == len(logs_retrieved)-1: # No new logs
-                    log_idx = len(logs_retrieved)
                 break
 
-        new_logs = '\n'.join(logs_retrieved[log_idx:])
-        if new_logs:
-            print(new_logs, end='')  # don't create \n @ the end
+        idx = log_idx+1 if log_idx else log_idx # First time getting logs, go to 0th index, else log_idx+1
+        for n in logs_retrieved[idx:]:
+            print(f'\n{n}',end='')
 
         previous_lines = copy.deepcopy(logs_retrieved)  # O(1) checking
         previous_lines = previous_lines if previous_lines[-1] else previous_lines[:-1] # Remove empty line


### PR DESCRIPTION
* Added optional parameters when storing models for conda dependency
* Optional parameter when storing model to specify model library. This gives Splice Library support for [these](https://www.mlflow.org/docs/1.8.0/models.html#built-in-model-flavors) model libraries, even if not natively installed on our system
* Added support for logging [pyfunc](https://www.mlflow.org/docs/1.8.0/models.html#python-function-python-function) models. This allows users to store and deploy models with custom code implementation and custom dependencies
* Fixed bug in job watcher where the same statuses were printed multiple times 