### PR TITLE
Make NSDS functions default upper case

### DIFF
--- a/splicemachine/spark/context.py
+++ b/splicemachine/spark/context.py
@@ -178,14 +178,14 @@ class PySpliceContext:
         """
         return DataFrame(self.context.df(sql), self.spark_sql_context)
 
-    def insert(self, dataframe, schema_table_name, to_upper=False):
+    def insert(self, dataframe, schema_table_name, to_upper=True):
         """
         Insert a dataframe into a table (schema.table).
 
         :param dataframe: (Dataframe) The dataframe you would like to insert
         :param schema_table_name: (str) The table in which you would like to insert the DF
         :param to_upper: (bool) If the dataframe columns should be converted to uppercase before table creation
-                            If False, the table will be created with lower case columns. [Default False]
+                            If False, the table will be created with lower case columns. [Default True]
         :return: None
         """
         if to_upper:
@@ -591,7 +591,7 @@ class PySpliceContext:
         """
         return self.spark_session._jsparkSession.parseDataType(schema.json())
 
-    def createTable(self, dataframe, schema_table_name, primary_keys=None, create_table_options=None, to_upper=False, drop_table=False):
+    def createTable(self, dataframe, schema_table_name, primary_keys=None, create_table_options=None, to_upper=True, drop_table=False):
         """
         Creates a schema.table (schema_table_name) from a dataframe
         
@@ -600,7 +600,7 @@ class PySpliceContext:
         :param primary_keys: List[str] the primary keys. Default None
         :param create_table_options: str The additional table-level SQL options default None
         :param to_upper: bool If the dataframe columns should be converted to uppercase before table creation. \
-            If False, the table will be created with lower case columns. Default False
+            If False, the table will be created with lower case columns. Default True
         :param drop_table: bool whether to drop the table if it exists. Default False. If False and the table exists, the function will throw an exception
         :return: None
 


### PR DESCRIPTION
Fix because the database is case sensitive. Users using dataframes will run into problems trying to create and then insert rows into tables because of case sensitivity