### PR TITLE
Dbaas 4800

### DIFF
--- a/splicemachine/mlflow_support/mlflow_support.py
+++ b/splicemachine/mlflow_support/mlflow_support.py
@@ -1001,7 +1001,7 @@ def apply_patches():
     targets = [_register_feature_store, _register_splice_context, _lp, _lm, _timer, _log_artifact, _log_feature_transformations,
                _log_model_params, _log_pipeline_stages, _log_model, _load_model, _download_artifact,
                _start_run, _current_run_id, _current_exp_id, _deploy_aws, _deploy_azure, _deploy_db, _login_director,
-               _get_run_ids_by_name, _get_deployed_models, _deploy_kubernetes, _fetch_logs, _watch_job]
+               _get_run_ids_by_name, _get_deployed_models, _deploy_kubernetes, _fetch_logs, _watch_job, _end_run]
 
     for target in targets:
         gorilla.apply(gorilla.Patch(mlflow, target.__name__.lstrip('_'), target, settings=_GORILLA_SETTINGS))

--- a/splicemachine/mlflow_support/mlflow_support.py
+++ b/splicemachine/mlflow_support/mlflow_support.py
@@ -106,6 +106,10 @@ _GORILLA_SETTINGS = gorilla.Settings(allow_hit=True, store_hit=True)
 _PYTHON_VERSION = py_version.split('|')[0].strip()
 
 class SpliceActiveRun(ActiveRun):
+    """
+    A wrapped active run for Splice Machine that calls our custom mlflow.end_run, so we can record the notebook
+    history
+    """
     def __exit__(self, exc_type, exc_val, exc_tb):
         status = RunStatus.FINISHED if exc_type is None else RunStatus.FAILED
         mlflow.end_run(RunStatus.to_string(status))

--- a/splicemachine/mlflow_support/mlflow_support.py
+++ b/splicemachine/mlflow_support/mlflow_support.py
@@ -408,9 +408,8 @@ def _end_run(status=RunStatus.to_string(RunStatus.FINISHED), save_html=True):
             os.system(f'jupyter nbconvert --to {typ} {temp_file.name}')
             mlflow.log_artifact(f'{temp_file.name[:-1]}.{ext}', name=f'{run_name}_run_log.{ext}')
     orig = gorilla.get_original_attribute(mlflow, "end_run")
-    # active_run: ActiveRun = orig(status=status)
-    # return SpliceActiveRun(active_run)
     orig(status=status)
+
 
 @_mlflow_patch('start_run')
 def _start_run(run_id=None, tags=None, experiment_id=None, run_name=None, nested=False):
@@ -456,7 +455,7 @@ def _start_run(run_id=None, tags=None, experiment_id=None, run_name=None, nested
     if hasattr(mlflow,'_active_training_set'):
         mlflow._active_training_set._register_metadata(mlflow)
 
-    return active_run
+    return SpliceActiveRun(active_run)
 
 
 @_mlflow_patch('log_pipeline_stages')

--- a/splicemachine/mlflow_support/mlflow_support.py
+++ b/splicemachine/mlflow_support/mlflow_support.py
@@ -400,7 +400,7 @@ def _end_run(status=RunStatus.to_string(RunStatus.FINISHED), save_html=True):
             mlflow.log_artifact(temp_file.name, name=f'{run_name}_run_log.ipynb')
             typ,ext = ('html','html') if save_html else ('script','py')
             os.system(f'jupyter nbconvert --to {typ} {temp_file.name}')
-            mlflow.log_artifact(f'{temp_file.name[:-1]}.{ext}', name=f'{run_name}_run_log.py')
+            mlflow.log_artifact(f'{temp_file.name[:-1]}.{ext}', name=f'{run_name}_run_log.{ext}')
     orig = gorilla.get_original_attribute(mlflow, "end_run")
     orig(status=status)
 

--- a/splicemachine/mlflow_support/mlflow_support.py
+++ b/splicemachine/mlflow_support/mlflow_support.py
@@ -401,7 +401,7 @@ def _end_run(status=RunStatus.to_string(RunStatus.FINISHED), save_html=True):
         --
         Active run: None
     """
-    if mlflow._notebook_history and hasattr(mlflow, '_splice_context'):
+    if mlflow._notebook_history and hasattr(mlflow, '_splice_context') and mlflow.active_run():
         with NamedTemporaryFile() as temp_file:
             nb = nbf.v4.new_notebook()
             nb['cells'] = [nbf.v4.new_code_cell(code) for code in ipython.history_manager.input_hist_raw]

--- a/splicemachine/mlflow_support/mlflow_support.py
+++ b/splicemachine/mlflow_support/mlflow_support.py
@@ -401,7 +401,7 @@ def _end_run(status=RunStatus.to_string(RunStatus.FINISHED), save_html=True):
         --
         Active run: None
     """
-    if mlflow._notebook_history:
+    if mlflow._notebook_history and hasattr(mlflow, '_splice_context'):
         with NamedTemporaryFile() as temp_file:
             nb = nbf.v4.new_notebook()
             nb['cells'] = [nbf.v4.new_code_cell(code) for code in ipython.history_manager.input_hist_raw]

--- a/splicemachine/mlflow_support/mlflow_support.py
+++ b/splicemachine/mlflow_support/mlflow_support.py
@@ -408,9 +408,9 @@ def _end_run(status=RunStatus.to_string(RunStatus.FINISHED), save_html=True):
             os.system(f'jupyter nbconvert --to {typ} {temp_file.name}')
             mlflow.log_artifact(f'{temp_file.name[:-1]}.{ext}', name=f'{run_name}_run_log.{ext}')
     orig = gorilla.get_original_attribute(mlflow, "end_run")
-    active_run = orig(status=status)
-    return SpliceActiveRun(active_run)
-
+    # active_run: ActiveRun = orig(status=status)
+    # return SpliceActiveRun(active_run)
+    orig(status=status)
 
 @_mlflow_patch('start_run')
 def _start_run(run_id=None, tags=None, experiment_id=None, run_name=None, nested=False):


### PR DESCRIPTION
This new functionality adds traceability to mlflow runs.

When a run ends, we log to mlflow the history of all jupyter code cells that have been run up to this point. Even if they are run out of order, the in-order execution is saved. This allows data scientists to go back and see exactly how they created the run that they created.