### PR TITLE
Added functions to display feature and model drift plots for a given deployed model

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,7 +46,7 @@ autodoc_default_options = {
     'private-members':True,
     'inherited-members':True,
     'undoc-members': False, 
-    'exclude-members': '_validate_feature_vector_keys,_process_features,__prune_features_for_elimination,_register_metadata,_register_metadata,__update_deployment_status,__log_mlflow_results,__get_feature_importance,__get_pipeline,_validate_training_view,_validate_feature_set,_validate_feature,__validate_feature_data_type,_check_for_splice_ctx,_dropTableIfExists, _generateDBSchema,_getCreateTableSchema,_jstructtype,_spliceSparkPackagesName,_splicemachineContext,apply_patches, main'
+    'exclude-members': '_retrieve_model_data_sets,_retrieve_training_set_metadata_from_deployement,_validate_feature_vector_keys,_process_features,__prune_features_for_elimination,_register_metadata,_register_metadata,__update_deployment_status,__log_mlflow_results,__get_feature_importance,__get_pipeline,_validate_training_view,_validate_feature_set,_validate_feature,__validate_feature_data_type,_check_for_splice_ctx,_dropTableIfExists, _generateDBSchema,_getCreateTableSchema,_jstructtype,_spliceSparkPackagesName,_splicemachineContext,apply_patches, main'
 }
 
 # Add any paths that contain templates here, relative to this directory.

--- a/splicemachine/features/constants.py
+++ b/splicemachine/features/constants.py
@@ -191,6 +191,26 @@ class SQL:
     SELECT {feature_names} FROM {feature_sets} WHERE 
     """
 
+    get_deployment_metadata = f"""
+        SELECT tv.name, d.training_set_start_ts, d.training_set_end_ts,
+               string_agg(f.name,',') features
+        FROM featurestore.deployment d
+           INNER JOIN {FEATURE_STORE_SCHEMA}.training_set ts          ON d.training_set_id=ts.training_set_id 
+           INNER JOIN {FEATURE_STORE_SCHEMA}.training_set_feature tsf ON tsf.training_set_id=d.training_set_id
+           LEFT OUTER JOIN {FEATURE_STORE_SCHEMA}.training_view tv    ON tv.view_id = ts.view_id
+           INNER JOIN {FEATURE_STORE_SCHEMA}.feature f                ON tsf.feature_id=f.feature_id
+        WHERE d.model_schema_name = '{{schema_name}}'
+          AND d.model_table_name = '{{table_name}}'
+        GROUP BY 1,2,3
+        """
+
+    get_model_predictions = """
+            SELECT EVAL_TIME,
+                   PREDICTION 
+            FROM {schema_name}.{table_name} WHERE EVAL_TIME>='{start_time}' AND EVAL_TIME<'{end_time}'
+            ORDER BY EVAL_TIME
+            """
+
 class Columns:
     feature = ['feature_id', 'feature_set_id', 'name', 'description', 'feature_data_type', 'feature_type',
                'tags', 'compliance_level', 'last_update_ts', 'last_update_username']

--- a/splicemachine/features/feature_store.py
+++ b/splicemachine/features/feature_store.py
@@ -16,7 +16,7 @@ from splicemachine import SpliceMachineException
 from splicemachine.spark import PySpliceContext
 from splicemachine.features import Feature, FeatureSet
 from .training_set import TrainingSet
-from .utils.drift_utils import add_feature_plot, remove_outliers, datetime_range_split
+from .utils.drift_utils import (add_feature_plot, remove_outliers, datetime_range_split)
 from .utils.training_utils import (dict_to_lower, _generate_training_set_history_sql,
                                    _generate_training_set_sql, _create_temp_training_view)
 from .constants import SQL, FeatureType

--- a/splicemachine/features/feature_store.py
+++ b/splicemachine/features/feature_store.py
@@ -333,7 +333,7 @@ class FeatureStore:
         if current_values_only:
             ts.start_time = ts.end_time
 
-        if hasattr(self, 'mlflow_ctx'):
+        if hasattr(self, 'mlflow_ctx' and not return_sql):
             self.mlflow_ctx._active_training_set: TrainingSet = ts
             ts._register_metadata(self.mlflow_ctx)
         return sql if return_sql else self.splice_ctx.df(sql)

--- a/splicemachine/features/feature_store.py
+++ b/splicemachine/features/feature_store.py
@@ -775,6 +775,8 @@ class FeatureStore:
             n_bins = 15
             num_features = len(final_features)
             n_rows = int(num_features / 5)
+            if num_features % 5 > 0:
+                n_rows = n_rows + 1
             fig, axes = subplots(nrows=n_rows, ncols=5, figsize=(30, 10 * n_rows))
             axes = axes.flatten()
             # calculate combined plots for each feature
@@ -834,6 +836,8 @@ class FeatureStore:
         if max_ts > min_ts:
             intervals = self._datetime_range(min_ts, max_ts, time_intervals)
             n_rows = int(time_intervals / 5)
+            if time_intervals % 5 > 0:
+                n_rows = n_rows + 1
             fig, axes = plt.subplots(nrows=n_rows, ncols=5, figsize=(30, 10 * n_rows))
             axes = axes.flatten()
             for i, time_int in enumerate(intervals):

--- a/splicemachine/features/feature_store.py
+++ b/splicemachine/features/feature_store.py
@@ -333,7 +333,7 @@ class FeatureStore:
         if current_values_only:
             ts.start_time = ts.end_time
 
-        if hasattr(self, 'mlflow_ctx' and not return_sql):
+        if hasattr(self, 'mlflow_ctx') and not return_sql:
             self.mlflow_ctx._active_training_set: TrainingSet = ts
             ts._register_metadata(self.mlflow_ctx)
         return sql if return_sql else self.splice_ctx.df(sql)

--- a/splicemachine/features/feature_store.py
+++ b/splicemachine/features/feature_store.py
@@ -25,6 +25,7 @@ from .training_view import TrainingView
 class FeatureStore:
     def __init__(self, splice_ctx: PySpliceContext) -> None:
         self.splice_ctx = splice_ctx
+        self.mlflow_ctx = None
         self.feature_sets = []  # Cache of newly created feature sets
 
     def register_splice_context(self, splice_ctx: PySpliceContext) -> None:
@@ -166,7 +167,7 @@ class FeatureStore:
         Gets a feature vector given a list of Features and primary key values for their corresponding Feature Sets
 
         :param features: List of str Feature names or Features
-        :param join_key_values: (dict) join key vals to get the proper Feature values formatted as {join_key_column_name: join_key_value}
+        :param join_key_values: (dict) join key values to get the proper Feature values formatted as {join_key_column_name: join_key_value}
         :param return_sql: Whether to return the SQL needed to get the vector or the values themselves. Default False
         :return: Pandas Dataframe or str (SQL statement)
         """
@@ -735,12 +736,16 @@ class FeatureStore:
         :param name: MLflow run name
         :param rounds: Number of rounds of feature elimination that were run
         :param mlflow_results: The params / metrics to log
-        :return:
         """
-        with self.mlflow_ctx.start_run(run_name=name):
+        try:
+            if self.mlflow_ctx.active_run():
+                self.mlflow_ctx.start_run(run_name=name)
             for r in range(rounds):
                 with self.mlflow_ctx.start_run(run_name=f'Round {r}', nested=True):
                     self.mlflow_ctx.log_metrics(mlflow_results[r])
+        finally:
+            self.mlflow_ctx.end_run()
+
 
     def __prune_features_for_elimination(self, features) -> List[Feature]:
         """

--- a/splicemachine/features/feature_store.py
+++ b/splicemachine/features/feature_store.py
@@ -16,8 +16,8 @@ from splicemachine import SpliceMachineException
 from splicemachine.spark import PySpliceContext
 from splicemachine.features import Feature, FeatureSet
 from .training_set import TrainingSet
-from .utils import (dict_to_lower, _generate_training_set_history_sql,
-                    _generate_training_set_sql, _create_temp_training_view)
+from .utils.training_utils import (dict_to_lower, _generate_training_set_history_sql,
+                                   _generate_training_set_sql, _create_temp_training_view)
 from .constants import SQL, FeatureType
 from .training_view import TrainingView
 

--- a/splicemachine/features/feature_store.py
+++ b/splicemachine/features/feature_store.py
@@ -16,6 +16,7 @@ from splicemachine import SpliceMachineException
 from splicemachine.spark import PySpliceContext
 from splicemachine.features import Feature, FeatureSet
 from .training_set import TrainingSet
+from .utils.drift_utils import add_feature_plot, remove_outliers, datetime_range_split
 from .utils.training_utils import (dict_to_lower, _generate_training_set_history_sql,
                                    _generate_training_set_sql, _create_temp_training_view)
 from .constants import SQL, FeatureType
@@ -687,20 +688,20 @@ class FeatureStore:
     def set_feature_description(self):
         raise NotImplementedError
 
-    def _retrieve_training_set_from_deployment(self, schema_name, table_name):
+    def _retrieve_training_set_from_deployment( self, schema_name, table_name):
         metadata = self._retrieve_training_set_metadata_from_deployement(schema_name, table_name)
         features = metadata['FEATURES'].split(',')
         tv_name = metadata['NAME']
         start_time = metadata['TRAINING_SET_START_TS']
         end_time = metadata['TRAINING_SET_END_TS']
-        if (tv_name):
+        if tv_name:
             training_set_df = self.get_training_set_from_view(training_view=tv_name, start_time=start_time,
                                                               end_time=end_time, features=features)
         else:
             training_set_df = self.get_training_set(features=features, start_time=start_time, end_time=end_time)
         return training_set_df
 
-    def _retrieve_model_data_sets(self, schema_name, table_name):
+    def _retrieve_model_data_sets( self, schema_name, table_name):
         training_set_df = self._retrieve_training_set_from_deployment(schema_name, table_name)
         model_table_df = self.splice_ctx.df(f'SELECT * FROM {schema_name}.{table_name}')
         return training_set_df, model_table_df
@@ -709,53 +710,8 @@ class FeatureStore:
         sql = SQL.get_deployment_metadata.format(schema_name=schema_name, table_name=table_name)
         deploy_df = self.splice_ctx.df(sql).collect()
         cnt = len(deploy_df)
-        if (cnt == 1):
+        if cnt == 1:
             return deploy_df[0]
-
-    def _calculate_bounds(self, df, column_name):
-        """
-        Calculates outlier bounds based on interquartile range of distribution of values in column 'column_name'
-        from data set in data frame 'df'.
-        :param df: data frame containing data to be analyzed
-        :param column_name: column name to analyze
-        :return: dictionary with keys min, max, q1 and q3 keys and corresponding values for outlier minimum, maximum
-        and 25th and 75th percentile values (q1,q3)
-        """
-        bounds = dict(zip(["q1", "q3"], df.approxQuantile(column_name, [0.25, 0.75], 0)))
-        iqr = bounds['q3'] - bounds['q1']
-        bounds['min'] = bounds['q1'] - (iqr * 1.5)
-        bounds['max'] = bounds['q3'] + (iqr * 1.5)
-        return bounds
-
-    def _remove_outliers(self, df, column_name):
-        '''
-        Calculates outlier bounds no distribution of 'column_name' values and returns a filtered data frame without
-        outliers in the specified column.
-        :param df: data frame with data to remove outliers from
-        :param column_name: name of column to remove outliers from
-        :return: input data frame filtered to remove outliers
-        '''
-        import pyspark.sql.functions as f
-        bounds = self._calculate_bounds(df, column_name)
-        return df.filter((f.col(column_name) >= bounds['min']) & (f.col(column_name) <= bounds['max']))
-
-    def _add_feature_plot(self, ax, train_df, model_df, feature, n_bins):
-        '''
-        Adds a distplot of the outlier free feature values from both train_df and model_df data frames which both
-        contain the feature.
-        :param ax: target subplot for chart
-        :param train_df: training data containing feature of interest
-        :param model_df: model input data also containing feature of interest
-        :param feature: name of feature to display in distribution histogram
-        :param n_bins: number of bins to use in histogram plot
-        :return: None
-        '''
-        from pyspark_dist_explore import distplot
-        import pyspark.sql.functions as f
-        distplot(ax, [self._remove_outliers(train_df.select(f.col(feature).alias('training')), 'training'),
-                      self._remove_outliers(model_df.select(f.col(feature).alias('model')), 'model')], bins=n_bins)
-        ax.set_title(feature)
-        ax.legend()
 
     def display_model_feature_drift(self, schema_name, table_name):
         """
@@ -781,26 +737,11 @@ class FeatureStore:
             axes = axes.flatten()
             # calculate combined plots for each feature
             for plot, f in enumerate(final_features):
-                self._add_feature_plot(axes[plot], training_set_df, model_table_df, f, n_bins)
+                add_feature_plot(axes[plot], training_set_df, model_table_df, f, n_bins)
             show()
         else:
             print(f"Could not find deployment for model table {schema_name}.{table_name}")
 
-    def _datetime_range(self, start: datetime, end: datetime, number: int):
-        """
-        Subdivides the time frame defined by 'start' and 'end' parameters into 'number' equal time frames.
-        :param start: start date time
-        :param end: end date time
-        :param number: number of time frames to split into
-        :return: list of start/end date times
-        """
-        from datetime import datetime
-        from itertools import count, islice
-        start_secs = (start - datetime(1970, 1, 1)).total_seconds()
-        end_secs = (end - datetime(1970, 1, 1)).total_seconds()
-        dates = [datetime.fromtimestamp(el) for el in
-                 islice(count(start_secs, (end_secs - start_secs) / number), number + 1)]
-        return zip(dates, dates[1:])
 
     def display_model_drift(self, schema_name: str, table_name: str, time_intervals: int,
                             start_time: datetime = None, end_time: datetime = None):
@@ -834,7 +775,7 @@ class FeatureStore:
         max_ts = model_table_df.orderBy(f.col("EVAL_TIME").desc()).first()['EVAL_TIME']
 
         if max_ts > min_ts:
-            intervals = self._datetime_range(min_ts, max_ts, time_intervals)
+            intervals = datetime_range_split(min_ts, max_ts, time_intervals)
             n_rows = int(time_intervals / 5)
             if time_intervals % 5 > 0:
                 n_rows = n_rows + 1
@@ -842,12 +783,12 @@ class FeatureStore:
             axes = axes.flatten()
             for i, time_int in enumerate(intervals):
                 df = model_table_df.filter((f.col('EVAL_TIME') >= time_int[0]) & (f.col('EVAL_TIME') < time_int[1]))
-                distplot(axes[i], [self._remove_outliers(df.select(f.col('PREDICTION')), 'PREDICTION')], bins=15)
+                distplot(axes[i], [remove_outliers(df.select(f.col('PREDICTION')), 'PREDICTION')], bins=15)
                 axes[i].set_title(f"{time_int[0]}")
                 axes[i].legend()
         else:
             fig, axes = plt.subplots(nrows=1, ncols=1, figsize=(10, 10))
-            distplot(axes, [self._remove_outliers(model_table_df.select(f.col('PREDICTION')), 'PREDICTION')], bins=15)
+            distplot(axes, [remove_outliers(model_table_df.select(f.col('PREDICTION')), 'PREDICTION')], bins=15)
             axes.set_title(f"Predictions at {min_ts}")
             axes.legend()
 

--- a/splicemachine/features/training_set.py
+++ b/splicemachine/features/training_set.py
@@ -19,7 +19,7 @@ class TrainingSet:
                  ):
         self.training_view = training_view
         self.features = features
-        self.start_time = start_time or datetime.min
+        self.start_time = start_time or datetime(year=1990,month=1,day=1) # Saw problems with spark handling datetime.min
         self.end_time = end_time or datetime.today()
 
     def _register_metadata(self, mlflow_ctx):

--- a/splicemachine/features/training_set.py
+++ b/splicemachine/features/training_set.py
@@ -42,11 +42,13 @@ class TrainingSet:
                     mlflow_ctx.lp(f'splice.feature_store.training_set_feature_{i}',f.name)
             except:
                 raise SpliceMachineException("It looks like your active run already has a Training Set logged to it. "
-                                             "If you've called fs.get_training_set or fs.get_training_set_from_view "
-                                             "before starting this run, then that Training Set was logged to the current "
-                                             "active run. If you call fs.get_training_set or fs.get_training_set_from_view "
-                                             "before starting an mlflow run, all following runs will assume that Training "
-                                             "Set to be the active Training Set, and will log the Training Set as metadata. "
-                                             "For more information, refer to the documentation. If you'd like to use a "
-                                             "new Training Set, end the current run, call one of the mentioned "
-                                             "functions, and start your new run.") from None
+                                             "You cannot get a new active Training Set during an active run if you "
+                                             "already have an active Training Set. If you've called fs.get_training_set "
+                                             "or fs.get_training_set_from_view before starting this run, then that "
+                                             "Training Set was logged to the current active run. If you call "
+                                             "fs.get_training_set or fs.get_training_set_from_view before starting an "
+                                             "mlflow run, all following runs will assume that Training Set to be the "
+                                             "active Training Set, and will log the Training Set as metadata. For more "
+                                             "information, refer to the documentation. If you'd like to use a new "
+                                             "Training Set, end the current run, call one of the mentioned functions, "
+                                             "and start your new run.") from None

--- a/splicemachine/features/utils/drift_utils.py
+++ b/splicemachine/features/utils/drift_utils.py
@@ -1,3 +1,68 @@
 """
 A set of utility functions for calculating drift of deployed models
 """
+import datetime as datetime
+
+
+def calculate_outlier_bounds(df, column_name):
+    """
+    Calculates outlier bounds based on interquartile range of distribution of values in column 'column_name'
+    from data set in data frame 'df'.
+    :param df: data frame containing data to be analyzed
+    :param column_name: column name to analyze
+    :return: dictionary with keys min, max, q1 and q3 keys and corresponding values for outlier minimum, maximum
+    and 25th and 75th percentile values (q1,q3)
+    """
+    bounds = dict(zip(["q1", "q3"], df.approxQuantile(column_name, [0.25, 0.75], 0)))
+    iqr = bounds['q3'] - bounds['q1']
+    bounds['min'] = bounds['q1'] - (iqr * 1.5)
+    bounds['max'] = bounds['q3'] + (iqr * 1.5)
+    return bounds
+
+
+def remove_outliers(df, column_name):
+    """
+    Calculates outlier bounds no distribution of 'column_name' values and returns a filtered data frame without
+    outliers in the specified column.
+    :param df: data frame with data to remove outliers from
+    :param column_name: name of column to remove outliers from
+    :return: input data frame filtered to remove outliers
+    """
+    import pyspark.sql.functions as f
+    bounds = calculate_outlier_bounds(df, column_name)
+    return df.filter((f.col(column_name) >= bounds['min']) & (f.col(column_name) <= bounds['max']))
+
+
+def add_feature_plot(ax, train_df, model_df, feature, n_bins):
+    """
+    Adds a distplot of the outlier free feature values from both train_df and model_df data frames which both
+    contain the feature.
+    :param ax: target subplot for chart
+    :param train_df: training data containing feature of interest
+    :param model_df: model input data also containing feature of interest
+    :param feature: name of feature to display in distribution histogram
+    :param n_bins: number of bins to use in histogram plot
+    :return: None
+    """
+    from pyspark_dist_explore import distplot
+    import pyspark.sql.functions as f
+    distplot(ax, [remove_outliers(train_df.select(f.col(feature).alias('training')), 'training'),
+                  remove_outliers(model_df.select(f.col(feature).alias('model')), 'model')], bins=n_bins)
+    ax.set_title(feature)
+    ax.legend()
+
+
+def datetime_range_split( start: datetime, end: datetime, number: int):
+    """
+    Subdivides the time frame defined by 'start' and 'end' parameters into 'number' equal time frames.
+    :param start: start date time
+    :param end: end date time
+    :param number: number of time frames to split into
+    :return: list of start/end date times
+    """
+    from itertools import count, islice
+    start_secs = (start - datetime(1970, 1, 1)).total_seconds()
+    end_secs = (end - datetime(1970, 1, 1)).total_seconds()
+    dates = [datetime.fromtimestamp(el) for el in
+             islice(count(start_secs, (end_secs - start_secs) / number), number + 1)]
+    return zip(dates, dates[1:])

--- a/splicemachine/features/utils/drift_utils.py
+++ b/splicemachine/features/utils/drift_utils.py
@@ -1,0 +1,3 @@
+"""
+A set of utility functions for calculating drift of deployed models
+"""

--- a/splicemachine/features/utils/drift_utils.py
+++ b/splicemachine/features/utils/drift_utils.py
@@ -5,6 +5,9 @@ import datetime as datetime
 import matplotlib.pyplot as plt
 from datetime import datetime
 import pyspark.sql.functions as f
+from pyspark_dist_explore import distplot
+from itertools import count, islice
+
 
 def calculate_outlier_bounds(df, column_name):
     """
@@ -46,8 +49,6 @@ def add_feature_plot(ax, train_df, model_df, feature, n_bins):
     :param n_bins: number of bins to use in histogram plot
     :return: None
     """
-    from pyspark_dist_explore import distplot
-    import pyspark.sql.functions as f
     distplot(ax, [remove_outliers(train_df.select(f.col(feature).alias('training')), 'training'),
                   remove_outliers(model_df.select(f.col(feature).alias('model')), 'model')], bins=n_bins)
     ax.set_title(feature)
@@ -62,7 +63,6 @@ def datetime_range_split( start: datetime, end: datetime, number: int):
     :param number: number of time frames to split into
     :return: list of start/end date times
     """
-    from itertools import count, islice
     start_secs = (start - datetime(1970, 1, 1)).total_seconds()
     end_secs = (end - datetime(1970, 1, 1)).total_seconds()
     dates = [datetime.fromtimestamp(el) for el in
@@ -109,11 +109,11 @@ def build_model_drift_plot( model_table_df, time_intervals):
         axes = axes.flatten()
         for i, time_int in enumerate(intervals):
             df = model_table_df.filter((f.col('EVAL_TIME') >= time_int[0]) & (f.col('EVAL_TIME') < time_int[1]))
-            plt.distplot(axes[i], [remove_outliers(df.select(f.col('PREDICTION')), 'PREDICTION')], bins=15)
+            distplot(axes[i], [remove_outliers(df.select(f.col('PREDICTION')), 'PREDICTION')], bins=15)
             axes[i].set_title(f"{time_int[0]}")
             axes[i].legend()
     else:
         fig, axes = plt.subplots(nrows=1, ncols=1, figsize=(10, 10))
-        plt.distplot(axes, [remove_outliers(model_table_df.select(f.col('PREDICTION')), 'PREDICTION')], bins=15)
+        distplot(axes, [remove_outliers(model_table_df.select(f.col('PREDICTION')), 'PREDICTION')], bins=15)
         axes.set_title(f"Predictions at {min_ts}")
         axes.legend()

--- a/splicemachine/features/utils/training_utils.py
+++ b/splicemachine/features/utils/training_utils.py
@@ -1,9 +1,11 @@
 from splicemachine import SpliceMachineException
 from typing import List
-from .feature import Feature
-from .feature_set import FeatureSet
+from splicemachine.features import Feature, FeatureSet
 from splicemachine.features.training_view import TrainingView
 
+"""
+A set of utility functions for creating Training Set SQL 
+"""
 
 def clean_df(df, cols):
     for old, new in zip(df.columns, cols):

--- a/splicemachine/spark/context.py
+++ b/splicemachine/spark/context.py
@@ -124,8 +124,9 @@ class PySpliceContext:
 
     def fileToTable(self, file_path, schema_table_name, primary_keys=None, drop_table=False, **pandas_args):
         """
-        Load a file from the local filesystem and create a new table (or recreate an existing table), and load the data
-        from the file into the new table
+        Load a file from the local filesystem or from a remote location and create a new table
+        (or recreate an existing table), and load the data from the file into the new table. Any file_path that can be
+        read by pandas should work here.
 
         :param file_path: The local file to load
         :param schema_table_name: The schema.table name
@@ -133,7 +134,7 @@ class PySpliceContext:
         :param drop_table: Whether or not to drop the table. If this is False and the table already exists, the
             function will fail. Default False
         :param pandas_args: Extra parameters to be passed into the pd.read_csv function. Any parameters accepted
-        in pd.read_csv will work here
+            in pd.read_csv will work here
         :return: None
         """
         import pandas as pd


### PR DESCRIPTION
## Description
fs.display_model_drift( '<model_schema>','<model_table>', 10)
fs.display_model_feature_drift('<model_schema>','<model_table>')

## Motivation and Context
These methods provide a model monitoring mechanism that use the feature store metadata to figure out and retrieve the training set that the model was trained with, the model input values as used for predictions and the model predictions themselves to compare feature by feature training vs model feature values distributions and model prediction distributions.

## Dependencies
<!--- If this fix is dependent on code in other repos to be deployed, list that here. -->

## How Has This Been Tested?
Ran both methods on two different model deployments that are a part of the Feature Store demo notebooks (Notebook 7. Feature Drift - https://github.com/splicemachine/demos/blob/kaggle_retail/retail_feature_store/7.%20Feature%20Drift%20Analysis.ipynb )

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The test environment is featurestore2 database cluster on a GCP k8s cluster sales-gke-dev2 using DB version 3.0.1.1991


## Screenshots (if appropriate):
