### PR TITLE
DBAAS-4977: Migrate all SQL statements in the feature store api to SQLAlchemy

### DIFF
--- a/splicemachine/features/feature_set.py
+++ b/splicemachine/features/feature_set.py
@@ -3,10 +3,6 @@ from .constants import Columns
 from splicemachine.spark import PySpliceContext
 from typing import List, Dict
 
-FEATURE_SET_TS_COL = '\n\tLAST_UPDATE_TS TIMESTAMP'
-HISTORY_SET_TS_COL = '\n\tASOF_TS TIMESTAMP,\n\tUNTIL_TS TIMESTAMP'
-
-
 class FeatureSet:
     def __init__(self, *, splice_ctx: PySpliceContext = None, table_name, schema_name, description,
                  primary_keys: Dict[str, str], feature_set_id=None, deployed: bool = False, **kwargs):

--- a/splicemachine/features/feature_store.py
+++ b/splicemachine/features/feature_store.py
@@ -108,7 +108,7 @@ class FeatureStore:
         """
 
         r = make_request(self._FS_URL, Endpoints.FEATURES, RequestType.GET, { "name": names })
-        return [Feature(**f) for f in r] if as_list else pd.DataFrame(r, index=[0])
+        return [Feature(**f) for f in r] if as_list else pd.DataFrame.from_dict(r)
 
     def remove_feature_set(self):
         # TODO
@@ -209,7 +209,6 @@ class FeatureStore:
 
         r = make_request(self._FS_URL, Endpoints.TRAINING_SETS, RequestType.POST, { "current": current_values_only }, 
                         { "features": features, "start_time": start_time, "end_time": end_time })
-        sql = r['sql']
 
         # Here we create a null training view and pass it into the training set. We do this because this special kind
         # of training set isn't standard. It's not based on a training view, on primary key columns, a label column,
@@ -226,7 +225,7 @@ class FeatureStore:
 
         if self.mlflow_ctx and not return_sql:
             self.link_training_set_to_mlflow(features, start_time, end_time)
-        return sql if return_sql else self.splice_ctx.df(sql)
+        return r if return_sql else self.splice_ctx.df(r)
 
     def get_training_set_from_view(self, training_view: str, features: Union[List[Feature], List[str]] = None,
                                    start_time: Optional[datetime] = None, end_time: Optional[datetime] = None,

--- a/splicemachine/features/utils/http_utils.py
+++ b/splicemachine/features/utils/http_utils.py
@@ -53,7 +53,7 @@ def make_request(url: str, endpoint: str, method: RequestType, params: Dict[str,
     try:
         r.raise_for_status()
     except requests.exceptions.HTTPError as error:
-        to_print = str(error) if error.response.status_code == 500 else error.response.json()["detail"]
+        to_print = str(error) if error.response.status_code == 500 else error.response.json()["message"]
         raise SpliceMachineException(f'{to_print}') from None
     return r.json()
     # except requests.exceptions.HTTPError as e:


### PR DESCRIPTION
## Description
Converting all raw SQL queries to SQLAlchemy ORM-style queries
Fixes [DBAAS-4977](https://splicemachine.atlassian.net/browse/DBAAS-4977)

## Motivation and Context
Current implementation is not best practice

## Dependencies
Dependent on ml-workflow DBAAS-4977

## How Has This Been Tested?
Feature Store notebooks have been run and all functionality works exactly as it used to. All endpoints have been tested

