### PR TITLE
DBAAS-4979: Add standard authentication to the rest endpoints of the feature store api

### DIFF
--- a/splicemachine/features/feature_store.py
+++ b/splicemachine/features/feature_store.py
@@ -765,7 +765,7 @@ class FeatureStore:
     def set_feature_store_url(self, url: str):
         self._FS_URL = url
 
-    def login_director(self, username, password):
+    def login_fs(self, username, password):
         self._basic_auth = HTTPBasicAuth(username, password)
 
     def __try_auto_login(self):
@@ -777,4 +777,4 @@ class FeatureStore:
         """
         user, password = _get_credentials()
         if user and password:
-            self.login_director(user, password)
+            self.login_fs(user, password)

--- a/splicemachine/features/utils/http_utils.py
+++ b/splicemachine/features/utils/http_utils.py
@@ -46,7 +46,7 @@ def make_request(url: str, endpoint: str, method: RequestType, auth: HTTPBasicAu
     if not auth:
         raise Exception(
             "You have not logged into Feature Store director."
-            " Please run fs.login_director(username, password)"
+            " Please run fs.login_fs(username, password)"
         )
     if not url:
         raise KeyError("Uh Oh! FS_URL variable was not found... you should call 'fs.set_feature_store_url(<url>)' before doing trying again.")


### PR DESCRIPTION
## Description
Creates an HTTPBasicAuthentication for the user based on a username/password combination either pulled from env variables or manually inputted. Passes that auth to all HTTP calls to the FeatureStore API

## Motivation and Context
This is setup for when we have a security manager and token generation. When this happens, logic will already be in place to use it.
Relates to [DBAAS-4979](https://splicemachine.atlassian.net/browse/DBAAS-4979)

## Dependencies
Dependent on DBAAS-4979 in ml-worfklow

## How Has This Been Tested?
Tested by making calls to the feature store in the ml-workflow branch of the same name