### PR TITLE
summary endpoint working

### DIFF
--- a/splicemachine/features/feature_store.py
+++ b/splicemachine/features/feature_store.py
@@ -82,7 +82,7 @@ class FeatureStore:
         r = make_request(self._FS_URL, Endpoints.SUMMARY, RequestType.GET, self._basic_auth)
         return r
 
-    def get_fs_summary(self, training_view: str) -> TrainingView:
+    def get_training_view(self, training_view: str) -> TrainingView:
         """
         Gets a training view by name
 

--- a/splicemachine/features/feature_store.py
+++ b/splicemachine/features/feature_store.py
@@ -65,7 +65,24 @@ class FeatureStore:
         """
         raise NotImplementedError
 
-    def get_training_view(self, training_view: str) -> TrainingView:
+    def get_summary(self) -> TrainingView:
+        """
+        This function returns a summary of the feature store including:
+            * Number of feature sets
+            * Number of deployed feature sets
+            * Number of features
+            * Number of deployed features
+            * Number of training sets
+            * Number of training views
+            * Number of associated models - this is a count of the MLManager.RUNS table where the `splice.model_name` tag is set and the `splice.feature_store.training_set` parameter is set
+            * Number of active (deployed) models (that have used the feature store for training)
+            * Number of pending feature sets - this will will require a new table `featurestore.pending_feature_set_deployments` and it will be a count of that
+        """
+
+        r = make_request(self._FS_URL, Endpoints.SUMMARY, RequestType.GET, self._basic_auth)
+        return r
+
+    def get_fs_summary(self, training_view: str) -> TrainingView:
         """
         Gets a training view by name
 

--- a/splicemachine/features/utils/http_utils.py
+++ b/splicemachine/features/utils/http_utils.py
@@ -41,8 +41,9 @@ class Endpoints:
     TRAINING_VIEW_DESCRIPTIONS: str = "training-view-descriptions"
     TRAINING_VIEW_FEATURES: str = "training-view-features"
     TRAINING_VIEW_ID: str = "training-view-id"
+    SUMMARY: str = "summary"
 
-def make_request(url: str, endpoint: str, method: RequestType, auth: HTTPBasicAuth, params: Dict[str, Union[str, List[Union[str, int]]]] = None, body: Dict[str, str] = None) -> requests.Response:
+def make_request(url: str, endpoint: str, method: str, auth: HTTPBasicAuth, params: Dict[str, Union[str, List[Union[str, int]]]] = None, body: Dict[str, str] = None) -> Union[dict,List[dict]]:
     if not auth:
         raise Exception(
             "You have not logged into Feature Store director."


### PR DESCRIPTION
python SDK API summary endpoint for the feature store UI 

Returns information about metrics of the active feature store


## Motivation and Context
UI Dashboard (but it should be on the python SDK as well)


## How Has This Been Tested?
```
In [12]: fs.get_summary()
Out[12]:
{'num_feature_sets': 4,
 'num_deployed_feature_sets': 1,
 'num_features': 4,
 'num_deployed_features': 1,
 'num_training_sets': 0,
 'num_training_views': 0,
 'num_models': 0,
 'num_deployed_models': 0,
 'num_pending_feature_set_deployments': 0}
```

## Screenshots (if appropriate):
