### PR TITLE
DBAAS-5104: modify the get_feature_sets route to take names instead of IDs

### DIFF
--- a/splicemachine/features/feature_store.py
+++ b/splicemachine/features/feature_store.py
@@ -44,7 +44,7 @@ class FeatureStore:
     def get_feature_sets(self, feature_set_names: List[str] = None) -> List[FeatureSet]:
         """
         Returns a list of available feature sets
-        :param feature_set_names: A list of feature set names. If none will return all FeatureSets
+        :param feature_set_names: A list of feature set names in the format '{schema_name}.{table_name}'. If none will return all FeatureSets
         :return: List[FeatureSet] the list of Feature Sets
         """
 

--- a/splicemachine/features/feature_store.py
+++ b/splicemachine/features/feature_store.py
@@ -41,17 +41,14 @@ class FeatureStore:
     def register_splice_context(self, splice_ctx: PySpliceContext) -> None:
         self.splice_ctx = splice_ctx
 
-    def get_feature_sets(self, feature_set_ids: List[int] = None, _filter: Dict[str, str] = None) -> List[FeatureSet]:
+    def get_feature_sets(self, feature_set_names: List[str] = None) -> List[FeatureSet]:
         """
         Returns a list of available feature sets
-
-        :param feature_set_ids: A list of feature set IDs. If none will return all FeatureSets
-        :param _filter: Dictionary of filters to apply to the query. This filter can be on any attribute of FeatureSets.
-            If None, will return all FeatureSets
+        :param feature_set_names: A list of feature set names. If none will return all FeatureSets
         :return: List[FeatureSet] the list of Feature Sets
         """
 
-        r = make_request(self._FS_URL, Endpoints.FEATURE_SETS, RequestType.GET, self._basic_auth, { "fsid": feature_set_ids } if feature_set_ids else None)
+        r = make_request(self._FS_URL, Endpoints.FEATURE_SETS, RequestType.GET, self._basic_auth, { "name": feature_set_names } if feature_set_names else None)
         return [FeatureSet(**fs) for fs in r]
 
     def remove_training_view(self, override=False):

--- a/splicemachine/features/feature_store.py
+++ b/splicemachine/features/feature_store.py
@@ -44,6 +44,7 @@ class FeatureStore:
     def get_feature_sets(self, feature_set_names: List[str] = None) -> List[FeatureSet]:
         """
         Returns a list of available feature sets
+        
         :param feature_set_names: A list of feature set names in the format '{schema_name}.{table_name}'. If none will return all FeatureSets
         :return: List[FeatureSet] the list of Feature Sets
         """


### PR DESCRIPTION
## Description
Allow users to pass in feature set names to get feature sets

## Motivation and Context
Users will not know the feature set ids 
Fixes [DBAAS-5104](https://splicemachine.atlassian.net/browse/DBAAS-5104)

## Dependencies
[ml-workflow](https://github.com/splicemachine/ml-workflow/pull/92)

## How Has This Been Tested?
Endpoint tested in local environment against standalone db. Success case and failed cases all working as expected