### PR TITLE
Remove training set

### DIFF
--- a/mlruns/0/meta.yaml
+++ b/mlruns/0/meta.yaml
@@ -1,4 +1,0 @@
-artifact_location: file:///Users/benepstein/Documents/Github/pysplice/mlruns/0
-experiment_id: '0'
-lifecycle_stage: active
-name: Default

--- a/mlruns/0/meta.yaml
+++ b/mlruns/0/meta.yaml
@@ -1,0 +1,4 @@
+artifact_location: file:///Users/benepstein/Documents/Github/pysplice/mlruns/0
+experiment_id: '0'
+lifecycle_stage: active
+name: Default

--- a/splicemachine/features/feature_store.py
+++ b/splicemachine/features/feature_store.py
@@ -785,6 +785,7 @@ class FeatureStore:
 
         self.mlflow_ctx._active_training_set: TrainingSet = ts
         ts._register_metadata(self.mlflow_ctx)
+
     
     def set_feature_store_url(self, url: str):
         self._FS_URL = url

--- a/splicemachine/features/training_set.py
+++ b/splicemachine/features/training_set.py
@@ -48,7 +48,8 @@ class TrainingSet:
                                              "Training Set was logged to the current active run. If you call "
                                              "fs.get_training_set or fs.get_training_set_from_view before starting an "
                                              "mlflow run, all following runs will assume that Training Set to be the "
-                                             "active Training Set, and will log the Training Set as metadata. For more "
-                                             "information, refer to the documentation. If you'd like to use a new "
-                                             "Training Set, end the current run, call one of the mentioned functions, "
-                                             "and start your new run.") from None
+                                             "active Training Set (until the next call to either of those functions), "
+                                             "and will log the Training Set as metadata. For more information, "
+                                             "refer to the documentation. If you'd like to use a new Training Set, "
+                                             "end the current run, call one of the mentioned functions, and start "
+                                             "your new run. Or, call mlflow.remove_active_training_set()") from None

--- a/splicemachine/mlflow_support/mlflow_support.py
+++ b/splicemachine/mlflow_support/mlflow_support.py
@@ -438,6 +438,16 @@ def _start_run(run_id=None, tags=None, experiment_id=None, run_name=None, nested
 
     return SpliceActiveRun(active_run)
 
+@_mlflow_patch('remove_active_training_set')
+def _remove_active_training_set():
+    """
+    Removes the active training set from mlflow. This function deletes mlflows active training set (retrieved from
+    the feature store), which will in turn stop the automated logging of features to the active mlflow run. To recreate
+    an active training set, call fs.get_training_set or fs.get_training_set_from_view in the Feature Store.
+    """
+    if hasattr(mlflow,'_active_training_set'):
+        del mlflow._active_training_set
+
 
 @_mlflow_patch('log_pipeline_stages')
 def _log_pipeline_stages(pipeline):
@@ -1002,7 +1012,8 @@ def apply_patches():
     targets = [_register_feature_store, _register_splice_context, _lp, _lm, _timer, _log_artifact, _log_feature_transformations,
                _log_model_params, _log_pipeline_stages, _log_model, _load_model, _download_artifact,
                _start_run, _current_run_id, _current_exp_id, _deploy_aws, _deploy_azure, _deploy_db, _login_director,
-               _get_run_ids_by_name, _get_deployed_models, _deploy_kubernetes, _fetch_logs, _watch_job, _end_run, _set_mlflow_uri]
+               _get_run_ids_by_name, _get_deployed_models, _deploy_kubernetes, _fetch_logs, _watch_job, _end_run,
+               _set_mlflow_uri, _remove_active_training_set]
 
     for target in targets:
         gorilla.apply(gorilla.Patch(mlflow, target.__name__.lstrip('_'), target, settings=_GORILLA_SETTINGS))


### PR DESCRIPTION
Previously, there was no supported way to remove a training set for a user, which could lead to complications and confusion. This is entirely client side logic, so nothing is necessary on the server. 


## Dependencies
None

## How Has This Been Tested?
Locally see screenshot 

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/22605641/108724498-624cb000-74f3-11eb-9576-5b2e434fedd8.png)
