### PR TITLE
DBAAS-5101: Add route to list out training set details for deployments

### DIFF
--- a/splicemachine/features/feature_store.py
+++ b/splicemachine/features/feature_store.py
@@ -553,6 +553,17 @@ class FeatureStore:
         """
         make_request(self._FS_URL, Endpoints.FEATURES, RequestType.DELETE, self._basic_auth, { "name": name })
 
+    def get_deployments(self, schema_name: str = None, table_name: str = None, training_set: str = None):
+        """
+        Returns a list of all (or specified) available deployments
+        :param schema_name: model schema name
+        :param table_name: model table name
+        :param training_set: training set name
+        :return: List[Deployment] the list of Deployments as dicts
+        """
+        return make_request(self._FS_URL, Endpoints.DEPLOYMENTS, RequestType.GET, self._basic_auth, 
+            { 'schema': schema_name, 'table': table_name, 'name': training_set })
+
     def _retrieve_model_data_sets(self, schema_name: str, table_name: str):
         """
         Returns the training set dataframe and model table dataframe for a given deployed model.

--- a/splicemachine/features/feature_store.py
+++ b/splicemachine/features/feature_store.py
@@ -296,6 +296,7 @@ class FeatureStore:
                         { "features": features, "start_time": start_time, "end_time": end_time })
         sql = r["sql"]
         tvw = TrainingView(**r["training_view"])
+        features = [Feature(**f) for f in r["features"]]
 
         # Link this to mlflow for model deployment
         if self.mlflow_ctx and not return_sql:
@@ -538,6 +539,7 @@ class FeatureStore:
         start_time = metadata['TRAINING_SET_START_TS']
         end_time = metadata['TRAINING_SET_END_TS']
         tv = TrainingView(**r['training_view']) if 'training_view' in r else None
+        features = [Feature(**f) for f in r["features"]]
 
         if self.mlflow_ctx:
             self.link_training_set_to_mlflow(features, start_time, end_time, tv)

--- a/splicemachine/features/feature_store.py
+++ b/splicemachine/features/feature_store.py
@@ -295,7 +295,7 @@ class FeatureStore:
         r = make_request(self._FS_URL, Endpoints.TRAINING_SET_FROM_VIEW, RequestType.POST, self._basic_auth, { "view": training_view }, 
                         { "features": features, "start_time": start_time, "end_time": end_time })
         sql = r["sql"]
-        tvw = r["training_view"]
+        tvw = TrainingView(**r["training_view"])
 
         # Link this to mlflow for model deployment
         if self.mlflow_ctx and not return_sql:
@@ -532,14 +532,15 @@ class FeatureStore:
             { "schema": schema_name, "table": table_name })
         metadata = r["metadata"]
         
-        sql = r["sql"]
+        sql = r['sql']
         features = metadata['FEATURES'].split(',')
         tv_name = metadata['NAME']
         start_time = metadata['TRAINING_SET_START_TS']
         end_time = metadata['TRAINING_SET_END_TS']
+        tv = TrainingView(**r['training_view']) if 'training_view' in r else None
 
         if self.mlflow_ctx:
-            self.link_training_set_to_mlflow(features, start_time, end_time, tv_name)
+            self.link_training_set_to_mlflow(features, start_time, end_time, tv)
         return self.splice_ctx.df(sql)
 
     def remove_feature(self, name: str):

--- a/splicemachine/features/utils/http_utils.py
+++ b/splicemachine/features/utils/http_utils.py
@@ -28,6 +28,7 @@ class Endpoints:
     """
     Enum for Feature Store Endpoints
     """
+    DEPLOYMENTS: str = "deployments"
     FEATURES: str = "features"
     FEATURE_SETS: str = "feature-sets"
     FEATURE_SET_DESCRIPTIONS: str = "feature-set-descriptions"


### PR DESCRIPTION
## Description
Adds a route that returns the information about deployed models and their associated training sets

## Motivation and Context
For the UI
Fixes [DBAAS-5101](https://splicemachine.atlassian.net/browse/DBAAS-5101)

## Dependencies
[ml-workflow](https://github.com/splicemachine/ml-workflow/pull/93)
## How Has This Been Tested?
Tested locally and on k8s cluster
