### PR TITLE
DBAAS-5102: create a route for GET /training-set-feature

### DIFF
--- a/splicemachine/features/feature_store.py
+++ b/splicemachine/features/feature_store.py
@@ -562,8 +562,8 @@ class FeatureStore:
         r = make_request(self._FS_URL, Endpoints.TRAINING_SET_FEATURES, RequestType.GET, self._basic_auth, 
             { 'name': training_set })
         training_set = r['training_set']
-        r['features'] = [Feature(**f) for f in r['features']]
-        return r
+        training_set['features'] = [Feature(**f) for f in r['features']]
+        return training_set
 
     def _retrieve_model_data_sets(self, schema_name: str, table_name: str):
         """

--- a/splicemachine/features/feature_store.py
+++ b/splicemachine/features/feature_store.py
@@ -528,13 +528,13 @@ class FeatureStore:
 
         r = make_request(self._FS_URL, Endpoints.TRAINING_SET_FROM_DEPLOYMENT, RequestType.GET, self._basic_auth, 
             { "schema": schema_name, "table": table_name })
-        metadata = r["metadata"]
+        metadata = r['metadata']
         
-        sql = r["sql"]
-        features = metadata['FEATURES'].split(',')
-        tv_name = metadata['NAME']
-        start_time = metadata['TRAINING_SET_START_TS']
-        end_time = metadata['TRAINING_SET_END_TS']
+        sql = r['sql']
+        features = r['features']
+        tv_name = metadata['name']
+        start_time = metadata['training_set_start_ts']
+        end_time = metadata['training_set_end_ts']
 
         if self.mlflow_ctx:
             self.link_training_set_to_mlflow(features, start_time, end_time, tv_name)

--- a/splicemachine/features/feature_store.py
+++ b/splicemachine/features/feature_store.py
@@ -438,8 +438,8 @@ class FeatureStore:
         
         print('Available feature sets')
         for desc in r:
-            fset = FeatureSet(**desc["feature_set"])
-            features = [Feature(**feature) for feature in desc["features"]]
+            features = [Feature(**feature) for feature in desc.pop('features')]
+            fset = FeatureSet(**desc)
             print('-' * 23)
             self._feature_set_describe(fset, features)
 
@@ -461,8 +461,8 @@ class FeatureStore:
         if not descs: raise SpliceMachineException(
             f"Feature Set {schema_name}.{table_name} not found. Check name and try again.")
         desc = descs[0]
-        fset = FeatureSet(**desc["feature_set"])
-        features = [Feature(**feature) for feature in desc["features"]]
+        features = [Feature(**feature) for feature in desc.pop("features")]
+        fset = FeatureSet(**desc)
         self._feature_set_describe(fset, features)
 
     def _feature_set_describe(self, fset: FeatureSet, features: List[Feature]):
@@ -482,8 +482,8 @@ class FeatureStore:
 
         print('Available training views')
         for desc in r:
-            tcx = TrainingView(**desc["training_view"])
-            features = [Feature(**f) for f in desc["features"]]
+            features = [Feature(**f) for f in desc.pop('features')]
+            tcx = TrainingView(**desc)
             print('-' * 23)
             self._training_view_describe(tcx, features)
 
@@ -499,8 +499,8 @@ class FeatureStore:
         descs = r
         if not descs: raise SpliceMachineException(f"Training view {training_view} not found. Check name and try again.")
         desc = descs[0]
-        tcx = TrainingView(**desc['training_view'])
-        feats = [Feature(**f) for f in desc['features']]
+        feats = [Feature(**f) for f in desc.pop('features')]
+        tcx = TrainingView(**desc)
         self._training_view_describe(tcx, feats)
 
     def _training_view_describe(self, tcx: TrainingView, feats: List[Feature]):
@@ -561,9 +561,8 @@ class FeatureStore:
         """
         r = make_request(self._FS_URL, Endpoints.TRAINING_SET_FEATURES, RequestType.GET, self._basic_auth, 
             { 'name': training_set })
-        training_set = r['training_set']
-        training_set['features'] = [Feature(**f) for f in r['features']]
-        return training_set
+        r['features'] = [Feature(**f) for f in r['features']]
+        return r
 
     def _retrieve_model_data_sets(self, schema_name: str, table_name: str):
         """

--- a/splicemachine/features/feature_store.py
+++ b/splicemachine/features/feature_store.py
@@ -551,6 +551,20 @@ class FeatureStore:
         """
         make_request(self._FS_URL, Endpoints.FEATURES, RequestType.DELETE, self._basic_auth, { "name": name })
 
+    def get_training_set_features(self, training_set: str = None):
+        """
+        Returns a list of all features from an available Training Set, as well as details about that Training Set
+        :param schema_name: model schema name
+        :param table_name: model table name
+        :param training_set: training set name
+        :return: List[Deployment] the list of Deployments as dicts
+        """
+        r = make_request(self._FS_URL, Endpoints.TRAINING_SET_FEATURES, RequestType.GET, self._basic_auth, 
+            { 'name': training_set })
+        training_set = r['training_set']
+        r['features'] = [Feature(**f) for f in r['features']]
+        return r
+
     def _retrieve_model_data_sets(self, schema_name: str, table_name: str):
         """
         Returns the training set dataframe and model table dataframe for a given deployed model.

--- a/splicemachine/features/utils/http_utils.py
+++ b/splicemachine/features/utils/http_utils.py
@@ -35,6 +35,7 @@ class Endpoints:
     FEATURE_VECTOR: str = "feature-vector"
     FEATURE_VECTOR_SQL: str = "feature-vector-sql"
     TRAINING_SETS: str = "training-sets"
+    TRAINING_SET_FEATURES: str = "training-set-features"
     TRAINING_SET_FROM_DEPLOYMENT: str = "training-set-from-deployment"
     TRAINING_SET_FROM_VIEW: str = "training-set-from-view"
     TRAINING_VIEWS: str = "training-views"


### PR DESCRIPTION
## Description
This returns all of the features for a particular training set along with info about that training set like start_time, end_time etc.

## Motivation and Context
Necessary for Cloud Manager UI
Fixes [DBAAS-5102](https://splicemachine.atlassian.net/browse/DBAAS-5102)

## Dependencies
[ml-workflow](https://github.com/splicemachine/ml-workflow/pull/94)
## How Has This Been Tested?
Tested locally and on k8s cluster
