### PR TITLE
Spark2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ pyspark-dist-explore==0.1.8
 numpy
 pandas
 scipy
-pyspark>=2.4.5,<=3.0.0
+pyspark>=2.4.5,<3.0.0
 h2o-pysparkling-2.4==3.28.1.2-1
 IPython
 cloudpickle==1.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ pyspark-dist-explore==0.1.8
 numpy
 pandas
 scipy
-pyspark>=2.4.5,<3.0.0
+pyspark>=2.4.0,<=2.4.5
 h2o-pysparkling-2.4==3.28.1.2-1
 IPython
 cloudpickle==1.6.0

--- a/requirements3.txt
+++ b/requirements3.txt
@@ -11,6 +11,6 @@ numpy
 pandas
 scipy
 pyspark>=3.0.1
-h2o-pysparkling-3.0
+h2o-pysparkling-3.0==3.32.0.4-1
 IPython
 cloudpickle==1.6.0

--- a/requirements3.txt
+++ b/requirements3.txt
@@ -1,7 +1,7 @@
-py4j==0.10.7.0
+py4j
 mlflow==1.8.0
 pyyaml
-mleap==0.15.0
+mleap==0.16.0
 graphviz
 requests
 gorilla==0.3.0
@@ -10,7 +10,7 @@ pyspark-dist-explore==0.1.8
 numpy
 pandas
 scipy
-pyspark>=2.4.5,<=3.0.0
-h2o-pysparkling-2.4==3.28.1.2-1
+pyspark>=3.0.1
+h2o-pysparkling-3.0
 IPython
 cloudpickle==1.6.0

--- a/splicemachine/features/feature_store.py
+++ b/splicemachine/features/feature_store.py
@@ -192,8 +192,7 @@ class FeatureStore:
         raise NotImplementedError
 
     def get_training_set(self, features: Union[List[Feature], List[str]], current_values_only: bool = False,
-                         label: str = None, start_time: datetime = None, end_time: datetime = None,
-                         return_sql: bool = False) -> SparkDF:
+                         start_time: datetime = None, end_time: datetime = None, return_sql: bool = False) -> SparkDF:
         """
         Gets a set of feature values across feature sets that is not time dependent (ie for non time series clustering).
         This feature dataset will be treated and tracked implicitly the same way a training_dataset is tracked from
@@ -217,10 +216,6 @@ class FeatureStore:
                     create a Training View to specify the join conditions.
 
         :param current_values_only: If you only want the most recent values of the features, set this to true. Otherwise, all history will be returned. Default False
-        :param label: An optional label to specify for the training set. If specified, the feature set of that feature
-            will be used as the "anchor" feature set, meaning all point in time joins will be made to the timestamps of
-            that feature set. This feature will also be recorded as a "label" feature for this particular training set
-            (but not others in the future, unless this label is again specified).
         :param start_time: How far back in history you want Feature values. If not specified (and current_values_only is False), all history will be returned.
             This parameter only takes effect if current_values_only is False.
         :param end_time: The most recent values for each selected Feature. This will be the cutoff time, such that any Feature values that

--- a/splicemachine/features/feature_store.py
+++ b/splicemachine/features/feature_store.py
@@ -192,7 +192,8 @@ class FeatureStore:
         raise NotImplementedError
 
     def get_training_set(self, features: Union[List[Feature], List[str]], current_values_only: bool = False,
-                         start_time: datetime = None, end_time: datetime = None, return_sql: bool = False) -> SparkDF:
+                         label: str = None, start_time: datetime = None, end_time: datetime = None,
+                         return_sql: bool = False) -> SparkDF:
         """
         Gets a set of feature values across feature sets that is not time dependent (ie for non time series clustering).
         This feature dataset will be treated and tracked implicitly the same way a training_dataset is tracked from
@@ -216,6 +217,10 @@ class FeatureStore:
                     create a Training View to specify the join conditions.
 
         :param current_values_only: If you only want the most recent values of the features, set this to true. Otherwise, all history will be returned. Default False
+        :param label: An optional label to specify for the training set. If specified, the feature set of that feature
+            will be used as the "anchor" feature set, meaning all point in time joins will be made to the timestamps of
+            that feature set. This feature will also be recorded as a "label" feature for this particular training set
+            (but not others in the future, unless this label is again specified).
         :param start_time: How far back in history you want Feature values. If not specified (and current_values_only is False), all history will be returned.
             This parameter only takes effect if current_values_only is False.
         :param end_time: The most recent values for each selected Feature. This will be the cutoff time, such that any Feature values that

--- a/splicemachine/mlflow_support/mlflow_support.py
+++ b/splicemachine/mlflow_support/mlflow_support.py
@@ -63,7 +63,8 @@ import pyspark
 import requests
 import sklearn
 import yaml
-from h2o.model.model_base import ModelBase as H2OModel
+# from h2o.model.model_base import ModelBase as H2OModel TODO: For Spark3
+from h2o.estimators.estimator_base import ModelBase as H2OModel
 from pandas.core.frame import DataFrame as PandasDF
 from pyspark.ml.base import Model as SparkModel
 from pyspark.sql import DataFrame as SparkDF


### PR DESCRIPTION
Spark 3 is not ready for production yet, but we want to release the feature store code. This is to revert things back to spark2 compatible states so we can release the new feature store without being dependent on spark3


## Dependencies
[ml-workflow](https://github.com/splicemachine/ml-workflow/pull/95)

## How Has This Been Tested?
Ran though the notebook suite and the twimlcon notebook demos