### PR TITLE
DBAAS-5123: Feature Set table redesign

### DIFF
--- a/splicemachine/features/training_set.py
+++ b/splicemachine/features/training_set.py
@@ -15,11 +15,13 @@ class TrainingSet:
                  *,
                  training_view: TrainingView,
                  features: List[Feature],
+                 create_time: datetime,
                  start_time: Optional[datetime] = None,
                  end_time: Optional[datetime] = None
                  ):
         self.training_view = training_view
         self.features = features
+        self.create_time = create_time
         self.start_time = start_time or datetime(year=1900,month=1,day=1) # Saw problems with spark handling datetime.min
         self.end_time = end_time or datetime.today()
 
@@ -37,6 +39,7 @@ class TrainingSet:
                 mlflow_ctx.lp("splice.feature_store.training_set",self.training_view.name)
                 mlflow_ctx.lp("splice.feature_store.training_set_start_time",str(self.start_time))
                 mlflow_ctx.lp("splice.feature_store.training_set_end_time",str(self.end_time))
+                mlflow_ctx.lp("splice.feature_store.training_set_create_time",str(self.create_time))
                 mlflow_ctx.lp("splice.feature_store.training_set_num_features", len(self.features))
                 for i,f in enumerate(self.features):
                     mlflow_ctx.lp(f'splice.feature_store.training_set_feature_{i}',f.name)


### PR DESCRIPTION
## Description
Training set queries that read history tables will now calculate period of applicability of feature set history on-the-fly at training set retrieval time. Additionally we have added the INGEST_TS to the history table structure which is automatically populated by the trigger logic always setting it to CURRENT_TIMESTAMP

## Motivation and Context
We’ve streamlined history-keeping by avoiding the need for period of applicability maintenance using an INSERT only model for history tables. Training set queries that read history tables will now calculate period of applicability of feature set history on-the-fly at training set retrieval time. By using INGETS_TS to filter out new history records, rebuilding training sets at a later time becomes simple by filtering on INGEST_TS < (point in time of the original query).
Fixes [DBAAS-5123](https://splicemachine.atlassian.net/browse/DBAAS-5123)

## Dependencies
[ml-workflow](https://github.com/splicemachine/ml-workflow/pull/96)

## How Has This Been Tested?
Tested all training set endpoints in local environment
