### PR TITLE
better checking on ipython history manager

### DIFF
--- a/splicemachine/mlflow_support/mlflow_support.py
+++ b/splicemachine/mlflow_support/mlflow_support.py
@@ -83,7 +83,7 @@ try:
     from IPython import get_ipython
     import nbformat as nbf
     ipython = get_ipython()
-    mlflow._notebook_history = True
+    mlflow._notebook_history = bool(ipython) # If running outside a notebook/ipython, this will be False
 except:
     mlflow._notebook_history = False
 
@@ -1027,7 +1027,7 @@ def _set_mlflow_uri(uri):
     :param uri: (str) the URL of your mlflow UI.
     :return: None
     """
-    _CLIENT = uri
+    _CLIENT = mlflow.tracking.MlflowClient(tracking_uri=uri)
     mlflow.client = _CLIENT
     mlflow.set_tracking_uri(uri)
 


### PR DESCRIPTION
If users were running our mlflow system through python scripts instead of through Ipython or Jupyter notebooks, it would fail because of logic around the "ipython history manager." This is only available when actively using jupyter/ipython. I added a check so this won't fail in the future.

## Testing

I ran the following through a python script locally and it worked

```
from splicemachine.mlflow_support import *
mlflow.set_mlflow_uri() # removed uri
mlflow.start_run()
mlflow.log_param('foo','bar')
mlflow.end_run()
```
and confirmed that it was available in the UI in the cluster.
