### PR TITLE
working delete

### DIFF
--- a/splicemachine/features/utils/http_utils.py
+++ b/splicemachine/features/utils/http_utils.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Union, Tuple
+from typing import List, Dict, Union, Tuple, Optional, Any
 import requests
 from splicemachine import SpliceMachineException
 from os import environ as env_vars
@@ -45,7 +45,9 @@ class Endpoints:
     TRAINING_VIEW_ID: str = "training-view-id"
     SUMMARY: str = "summary"
 
-def make_request(url: str, endpoint: str, method: str, auth: HTTPBasicAuth, params: Dict[str, Union[str, List[Union[str, int]]]] = None, body: Dict[str, str] = None) -> Union[dict,List[dict]]:
+def make_request(url: str, endpoint: str, method: str, auth: HTTPBasicAuth,
+                 params: Optional[Dict[str, Any]] = None,
+                 body: Union[Dict[str,Any], List[Any]] = None) -> Union[dict,List[dict]]:
     if not auth:
         raise Exception(
             "You have not logged into Feature Store director."


### PR DESCRIPTION
This function allows users to drop feature sets under a few scenarios
* The feature set is not deployed
* The feature set is deployed but has no associated training sets
* The feature set is deployed and has associated training set(s), but no associated models, and the user provided the `purge` parameter.


## Motivation and Context
It's necessary to be able to delete feature sets

## Dependencies
[ml-workflow](https://github.com/splicemachine/ml-workflow/pull/102)

## How Has This Been Tested?
Tests and api calls

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/22605641/110550297-68e94300-8101-11eb-8d7a-a414167a8ca9.png)
![image](https://user-images.githubusercontent.com/22605641/110550356-86b6a800-8101-11eb-83d7-79818894ff4a.png)
