### PR TITLE
DBAAS-5007: Allow label in get_training_set without a training view

### DIFF
--- a/splicemachine/features/feature_store.py
+++ b/splicemachine/features/feature_store.py
@@ -234,6 +234,7 @@ class FeatureStore:
         create_time = r['metadata']['training_set_create_ts']
         sql = r['sql']
         tvw = TrainingView(**r['training_view'])
+        features = [Feature(**f) for f in r['features']]
         # Here we create a null training view and pass it into the training set. We do this because this special kind
         # of training set isn't standard. It's not based on a training view, on primary key columns, a label column,
         # or a timestamp column . This is simply a joined set of features from different feature sets.

--- a/splicemachine/features/feature_store.py
+++ b/splicemachine/features/feature_store.py
@@ -227,6 +227,8 @@ class FeatureStore:
             will be used as the "anchor" feature set, meaning all point in time joins will be made to the timestamps of
             that feature set. This feature will also be recorded as a "label" feature for this particular training set
             (but not others in the future, unless this label is again specified).
+        :param return_pk_cols: bool Whether or not the returned sql should include the primary key column(s)
+        :param return_ts_cols: bool Whether or not the returned sql should include the timestamp column
         :return: Spark DF
         """
         features = [f if isinstance(f, str) else f.__dict__ for f in features]
@@ -293,6 +295,8 @@ class FeatureStore:
 
                     If end_time is None, query will get most recently available data
 
+        :param return_pk_cols: bool Whether or not the returned sql should include the primary key column(s)
+        :param return_ts_cols: bool Whether or not the returned sql should include the timestamp column
         :param return_sql: (Optional[bool]) Return the SQL statement (str) instead of the Spark DF. Defaults False
         :return: Optional[SparkDF, str] The Spark dataframe of the training set or the SQL that is used to generate it (for debugging)
         """
@@ -534,6 +538,12 @@ class FeatureStore:
         Reads Feature Store metadata to rebuild orginal training data set used for the given deployed model.
         :param schema_name: model schema name
         :param table_name: model table name
+        :param label: An optional label to specify for the training set. If specified, the feature set of that feature
+            will be used as the "anchor" feature set, meaning all point in time joins will be made to the timestamps of
+            that feature set. This feature will also be recorded as a "label" feature for this particular training set
+            (but not others in the future, unless this label is again specified).
+        :param return_pk_cols: bool Whether or not the returned sql should include the primary key column(s)
+        :param return_ts_cols: bool Whether or not the returned sql should include the timestamp column
         :return:
         """
         # database stores object names in upper case

--- a/splicemachine/features/training_set.py
+++ b/splicemachine/features/training_set.py
@@ -41,6 +41,7 @@ class TrainingSet:
                 mlflow_ctx.lp("splice.feature_store.training_set_end_time",str(self.end_time))
                 mlflow_ctx.lp("splice.feature_store.training_set_create_time",str(self.create_time))
                 mlflow_ctx.lp("splice.feature_store.training_set_num_features", len(self.features))
+                mlflow_ctx.lp("splice.feature_store.training_set_label", self.training_view.label_column)
                 for i,f in enumerate(self.features):
                     mlflow_ctx.lp(f'splice.feature_store.training_set_feature_{i}',f.name)
             except:


### PR DESCRIPTION
## Description
1. The get_training_set api gets an optional label param
2. The feature set that the specified label belongs to becomes the anchor set by default
3. Validation occurs to ensure all other features can be joined to the now defaulted anchor feature set

## Motivation and Context
A user should be able to specify a label even when they are not using a training view.
Fixes [DBAAS-5007](https://splicemachine.atlassian.net/browse/DBAAS-5007)

## Dependencies
[ml-worflow](https://github.com/splicemachine/ml-workflow/pull/103)

## How Has This Been Tested?
Tested against standalone and on k8s cluster using ML notebooks
