### PR TITLE
Dbaas 4924: remove_training_view

### DIFF
--- a/splicemachine/features/feature_store.py
+++ b/splicemachine/features/feature_store.py
@@ -61,7 +61,9 @@ class FeatureStore:
 
         :param name: The view name
         """
+        print(f"Removing Training View {name}")
         make_request(self._FS_URL, Endpoints.TRAINING_VIEWS, RequestType.DELETE, self._basic_auth, { "name": name })
+        print('Done')
 
     def get_summary(self) -> TrainingView:
         """
@@ -438,8 +440,9 @@ class FeatureStore:
         # database stores object names in upper case
         schema_name = schema_name.upper()
         table_name = table_name.upper()
-
+        print(f'Deploying Feature Set {schema_name}.{table_name}')
         make_request(self._FS_URL, Endpoints.DEPLOY_FEATURE_SET, RequestType.POST, self._basic_auth, { "schema": schema_name, "table": table_name })
+        print('Done')
 
     def describe_feature_sets(self) -> None:
         """
@@ -574,7 +577,9 @@ class FeatureStore:
             :param name: feature name
             :return:
         """
+        print(f"Removing feature {name}")
         make_request(self._FS_URL, Endpoints.FEATURES, RequestType.DELETE, self._basic_auth, { "name": name })
+        print('Done')
 
     def get_deployments(self, schema_name: str = None, table_name: str = None, training_set: str = None):
         """
@@ -617,8 +622,10 @@ class FeatureStore:
         if purge:
             warnings.warn("You've set purge=True, I hope you know what you are doing! This will delete any dependent"
                           " Training Sets (except ones used in an active model deployment)")
+        print(f'Removing Feature Set {schema}.{table}')
         make_request(self._FS_URL, Endpoints.FEATURE_SETS,
                      RequestType.DELETE, self._basic_auth, { "schema": schema, "table":table, "purge": purge })
+        print('Done')
 
     def _retrieve_model_data_sets(self, schema_name: str, table_name: str):
         """

--- a/splicemachine/features/feature_store.py
+++ b/splicemachine/features/feature_store.py
@@ -53,16 +53,15 @@ class FeatureStore:
                          { "name": feature_set_names } if feature_set_names else None)
         return [FeatureSet(**fs) for fs in r]
 
-    def remove_training_view(self, override=False):
+    def remove_training_view(self, name: str):
         """
-        Note: This function is not yet implemented.
-        Removes a training view. This will run 2 checks.
-            1. See if the training view is being used by a model in a deployment. If this is the case, the function will fail, always.
-            2. See if the training view is being used in any mlflow runs (non-deployed models). This will fail and return
-            a warning Telling the user that this training view is being used in mlflow runs (and the run_ids) and that
-            they will need to "override" this function to forcefully remove the training view.
+        This removes a training view if it is not being used by any currently deployed models.
+        NOTE: Once this training view is removed, you will not be able to deploy any models that were trained using this
+        view
+
+        :param name: The view name
         """
-        raise NotImplementedError
+        make_request(self._FS_URL, Endpoints.TRAINING_VIEWS, RequestType.DELETE, self._basic_auth, { "name": name })
 
     def get_summary(self) -> TrainingView:
         """

--- a/splicemachine/features/training_set.py
+++ b/splicemachine/features/training_set.py
@@ -37,6 +37,7 @@ class TrainingSet:
             print("There is an active mlflow run, your training set will be logged to that run.")
             try:
                 mlflow_ctx.lp("splice.feature_store.training_set",self.training_view.name)
+                mlflow_ctx.lp("splice.feature_store.training_view_id",self.training_view.view_id)
                 mlflow_ctx.lp("splice.feature_store.training_set_start_time",str(self.start_time))
                 mlflow_ctx.lp("splice.feature_store.training_set_end_time",str(self.end_time))
                 mlflow_ctx.lp("splice.feature_store.training_set_create_time",str(self.create_time))

--- a/splicemachine/features/training_view.py
+++ b/splicemachine/features/training_view.py
@@ -1,24 +1,26 @@
 from typing import List
 
 class TrainingView:
-    def __init__(self, *, pk_columns: List[str], ts_column, label_column, view_sql, name, description, **kwargs):
+    def __init__(self, *, pk_columns: List[str], ts_column, label_column, view_sql, name, description,
+                 view_id = None, **kwargs):
         self.pk_columns = pk_columns
         self.ts_column = ts_column
         self.label_column = label_column
         self.view_sql = view_sql
         self.name = name
         self.description = description
+        self.view_id = view_id
         args = {k.lower(): kwargs[k] for k in kwargs} # Make all keys lowercase
         args = {k: args[k].split(',') if 'columns' in k and isinstance(args[k], str) else args[k] for k in args} # Make value a list for specific pkcolumns and contextcolumns because Splice doesn't support Arrays
         self.__dict__.update(args)
-
 
     def __repr__(self):
         return f'TrainingView(' \
                f'PKColumns={self.pk_columns}, ' \
                f'TSColumn={self.ts_column}, ' \
                f'LabelColumn={self.label_column}, \n' \
-               f'ViewSQL={self.view_sql}'
+               f'ViewSQL={self.view_sql}, \n' \
+               f'ViewID={self.view_id}'
 
     def __str__(self):
         return self.__repr__()


### PR DESCRIPTION
Remove Training View function added

## Description
This allows users to remove training views that are not associated to model deployments. In order to properly do this, when linking a training set to mlflow, we must also log the training view ID (which was added here). This also added some printing statements for ease of use for users.

## Motivation and Context
It is necessary for keeping the feature store clean to be able to remove training views.

## Dependencies
[ml-workflow](https://github.com/splicemachine/ml-workflow/pull/106)

## How Has This Been Tested?
Local testing against standalone db and unit tests

![image](https://user-images.githubusercontent.com/22605641/111356933-38545c80-865f-11eb-8a8e-8c2539394588.png)



