### PR TITLE
Dbaas 5279 - Create feature set with features

### DIFF
--- a/splicemachine/features/feature_store.py
+++ b/splicemachine/features/feature_store.py
@@ -326,7 +326,7 @@ class FeatureStore:
 
 
     def create_feature_set(self, schema_name: str, table_name: str, primary_keys: Dict[str, str],
-                           desc: Optional[str] = None, features: List[Feature] = None) -> FeatureSet:
+                           desc: Optional[str] = None, features: Optional[List[Feature]] = None) -> FeatureSet:
         """
         Creates and returns a new feature set
 
@@ -335,41 +335,45 @@ class FeatureStore:
         :param primary_keys: The primary key column(s) of this feature set
         :param desc: The (optional) description
         :param features: An optional list of features. If provided, the Features will be created with the Feature Set
-            :Example:
-                .. code-block:: python
-                    f1 = Feature(
-                        name='my_first_feature',
-                        description='the first feature',
-                        feature_data_type='INT',
-                        feature_type=FeatureType.ordinal,
-                        tags=['good_feature','a new tag', 'ordinal'],
-                        attributes={'quality':'awesome'}
-                    )
-                    f2 = Feature(
-                        name='my_second_feature',
-                        description='the second feature',
-                        feature_data_type='FLOAT',
-                        feature_type=FeatureType.continuous,
-                        tags=['not_as_good_feature','a new tag'],
-                        attributes={'quality':'not as awesome'}
-                    )
-                    feats = [f1, f2]
-                    feature_set = fs.create_feature_set(
-                        schema_name='splice',
-                        table_name='foo',
-                        primary_keys={'MOMENT_KEY':"INT"},
-                        desc='test fset',
-                        features=feats
-                    )
+        :Example:
+            .. code-block:: python
+                from splicemachine.features import FeatureType, Feature
+                f1 = Feature(
+                    name='my_first_feature',
+                    description='the first feature',
+                    feature_data_type='INT',
+                    feature_type=FeatureType.ordinal,
+                    tags=['good_feature','a new tag', 'ordinal'],
+                    attributes={'quality':'awesome'}
+                )
+                f2 = Feature(
+                    name='my_second_feature',
+                    description='the second feature',
+                    feature_data_type='FLOAT',
+                    feature_type=FeatureType.continuous,
+                    tags=['not_as_good_feature','a new tag'],
+                    attributes={'quality':'not as awesome'}
+                )
+                feats = [f1, f2]
+                feature_set = fs.create_feature_set(
+                    schema_name='splice',
+                    table_name='foo',
+                    primary_keys={'MOMENT_KEY':"INT"},
+                    desc='test fset',
+                    features=feats
+                )
         :return: FeatureSet
         """
         # database stores object names in upper case
         schema_name = schema_name.upper()
         table_name = table_name.upper()
 
-        fset_dict = { "schema_name": schema_name, "table_name": table_name,
-                          "primary_keys": primary_keys,
-                          "description": desc }
+        features = [f.__dict__ for f in features] if features else None
+        fset_dict = { "schema_name": schema_name,
+                      "table_name": table_name,
+                      "primary_keys": primary_keys,
+                      "description": desc,
+                      "features": features}
 
         print(f'Registering feature set {schema_name}.{table_name} in Feature Store')
         r = make_request(self._FS_URL, Endpoints.FEATURE_SETS, RequestType.POST, self._basic_auth, body=fset_dict)

--- a/splicemachine/features/feature_store.py
+++ b/splicemachine/features/feature_store.py
@@ -337,6 +337,7 @@ class FeatureStore:
         :param features: An optional list of features. If provided, the Features will be created with the Feature Set
         :Example:
             .. code-block:: python
+
                 from splicemachine.features import FeatureType, Feature
                 f1 = Feature(
                     name='my_first_feature',
@@ -362,6 +363,7 @@ class FeatureStore:
                     desc='test fset',
                     features=feats
                 )
+
         :return: FeatureSet
         """
         # database stores object names in upper case
@@ -376,6 +378,8 @@ class FeatureStore:
                       "features": features}
 
         print(f'Registering feature set {schema_name}.{table_name} in Feature Store')
+        if features:
+            print(f'Registering {len(features)} features for {schema_name}.{table_name} in the Feature Store')
         r = make_request(self._FS_URL, Endpoints.FEATURE_SETS, RequestType.POST, self._basic_auth, body=fset_dict)
         return FeatureSet(**r)
 
@@ -506,7 +510,8 @@ class FeatureStore:
         schema_name = schema_name.upper()
         table_name = table_name.upper()
 
-        r = make_request(self._FS_URL, Endpoints.FEATURE_SET_DESCRIPTIONS, RequestType.GET, self._basic_auth)
+        r = make_request(self._FS_URL, Endpoints.FEATURE_SET_DESCRIPTIONS, RequestType.GET, self._basic_auth,
+                         params={'schema':schema_name, 'table':table_name})
         descs = r
         if not descs: raise SpliceMachineException(
             f"Feature Set {schema_name}.{table_name} not found. Check name and try again.")

--- a/splicemachine/features/feature_store.py
+++ b/splicemachine/features/feature_store.py
@@ -335,30 +335,32 @@ class FeatureStore:
         :param primary_keys: The primary key column(s) of this feature set
         :param desc: The (optional) description
         :param features: An optional list of features. If provided, the Features will be created with the Feature Set
-            ex: f1 = Feature(
-                    name='my_first_feature',
-                    description='the first feature',
-                    feature_data_type='INT',
-                    feature_type=FeatureType.ordinal,
-                    tags=['good_feature','a new tag', 'ordinal'],
-                    attributes={'quality':'awesome'}
-                )
-                f2 = Feature(
-                    name='my_second_feature',
-                    description='the second feature',
-                    feature_data_type='FLOAT',
-                    feature_type=FeatureType.continuous,
-                    tags=['not_as_good_feature','a new tag'],
-                    attributes={'quality':'not as awesome'}
-                )
-                feats = [f1, f2]
-                fs.create_feature_set(
-                    schema_name='splice',
-                    table_name='foo',
-                    primary_keys={'MOMENT_KEY':"INT"},
-                    desc='test fset',
-                    features=feats
-                )
+            :Example:
+                .. code-block:: python
+                    f1 = Feature(
+                        name='my_first_feature',
+                        description='the first feature',
+                        feature_data_type='INT',
+                        feature_type=FeatureType.ordinal,
+                        tags=['good_feature','a new tag', 'ordinal'],
+                        attributes={'quality':'awesome'}
+                    )
+                    f2 = Feature(
+                        name='my_second_feature',
+                        description='the second feature',
+                        feature_data_type='FLOAT',
+                        feature_type=FeatureType.continuous,
+                        tags=['not_as_good_feature','a new tag'],
+                        attributes={'quality':'not as awesome'}
+                    )
+                    feats = [f1, f2]
+                    feature_set = fs.create_feature_set(
+                        schema_name='splice',
+                        table_name='foo',
+                        primary_keys={'MOMENT_KEY':"INT"},
+                        desc='test fset',
+                        features=feats
+                    )
         :return: FeatureSet
         """
         # database stores object names in upper case

--- a/splicemachine/features/feature_store.py
+++ b/splicemachine/features/feature_store.py
@@ -326,7 +326,7 @@ class FeatureStore:
 
 
     def create_feature_set(self, schema_name: str, table_name: str, primary_keys: Dict[str, str],
-                           desc: Optional[str] = None) -> FeatureSet:
+                           desc: Optional[str] = None, features: List[Feature] = None) -> FeatureSet:
         """
         Creates and returns a new feature set
 
@@ -334,6 +334,31 @@ class FeatureStore:
         :param table_name: The table name for this feature set
         :param primary_keys: The primary key column(s) of this feature set
         :param desc: The (optional) description
+        :param features: An optional list of features. If provided, the Features will be created with the Feature Set
+            ex: f1 = Feature(
+                    name='my_first_feature',
+                    description='the first feature',
+                    feature_data_type='INT',
+                    feature_type=FeatureType.ordinal,
+                    tags=['good_feature','a new tag', 'ordinal'],
+                    attributes={'quality':'awesome'}
+                )
+                f2 = Feature(
+                    name='my_second_feature',
+                    description='the second feature',
+                    feature_data_type='FLOAT',
+                    feature_type=FeatureType.continuous,
+                    tags=['not_as_good_feature','a new tag'],
+                    attributes={'quality':'not as awesome'}
+                )
+                feats = [f1, f2]
+                fs.create_feature_set(
+                    schema_name='splice',
+                    table_name='foo',
+                    primary_keys={'MOMENT_KEY':"INT"},
+                    desc='test fset',
+                    features=feats
+                )
         :return: FeatureSet
         """
         # database stores object names in upper case
@@ -349,7 +374,7 @@ class FeatureStore:
         return FeatureSet(**r)
 
     def create_feature(self, schema_name: str, table_name: str, name: str, feature_data_type: str,
-                       feature_type: FeatureType, desc: str = None, tags: List[str] = None, attributes: Dict[str, str] = None):
+                       feature_type: str, desc: str = None, tags: List[str] = None, attributes: Dict[str, str] = None):
         """
         Add a feature to a feature set
 
@@ -373,6 +398,10 @@ class FeatureStore:
         # database stores object names in upper case
         schema_name = schema_name.upper()
         table_name = table_name.upper()
+
+        assert feature_type in FeatureType.get_valid(), f"The feature_type {feature_type} in not valid. Valid feature " \
+                                                        f"types include {FeatureType.get_valid()}. Use the FeatureType" \
+                                                        f" class provided by splicemachine.features"
 
         f_dict = { "name": name, "description": desc or '', "feature_data_type": feature_data_type,
                     "feature_type": feature_type, "tags": tags, "attributes": attributes }


### PR DESCRIPTION
Create a feature set and features in a single endpoint call

## Description
If users are creating a lot of features with their feature set, or they are creating from the UI, it may be easier to create a feature set and features in a single call. It's simpler and it'll perform much faster.

## Motivation and Context
UI and performance

## Dependencies
[ml-workflow](https://github.com/splicemachine/ml-workflow/pull/114)

## How Has This Been Tested?
See below

## Screenshots (if appropriate):
As seen in the [documentation](https://pysplice.readthedocs.io/en/dbaas-5279/splicemachine.features.html#splicemachine.features.feature_store.FeatureStore.create_feature_set)
![image](https://user-images.githubusercontent.com/22605641/112054054-79e77a80-8b2b-11eb-91c4-5b3ce6e71c80.png)
