### PR TITLE
DB-11789 NSDS Bulk Import to Return Count of Imported Rows

### DIFF
--- a/splicemachine/spark/context.py
+++ b/splicemachine/spark/context.py
@@ -572,12 +572,12 @@ class PySpliceContext:
         :param dataframe: (DataFrame)
         :param schema_table_name: (str) Full table name in the format of "schema.table"
         :param options: (Dict) Dictionary of options to be passed to --splice-properties; bulkImportDirectory is required
-        :return: None
+        :return: (int) Number of records imported
         """
         optionsMap = self.jvm.java.util.HashMap()
         for k, v in options.items():
             optionsMap.put(k, v)
-        self.context.bulkImportHFile(dataframe._jdf, schema_table_name, optionsMap)
+        return self.context.bulkImportHFile(dataframe._jdf, schema_table_name, optionsMap)
 
     def bulkImportHFileWithRdd(self, rdd, schema, schema_table_name, options):
         """
@@ -587,9 +587,9 @@ class PySpliceContext:
         :param schema: (StructType) The schema of the rows in the RDD
         :param schema_table_name: (str) Full table name in the format of "schema.table"
         :param options: (Dict) Dictionary of options to be passed to --splice-properties; bulkImportDirectory is required
-        :return: None
+        :return:  (int) Number of records imported
         """
-        self.bulkImportHFile(
+        return self.bulkImportHFile(
             self.createDataFrame(rdd, schema),
             schema_table_name,
             options


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
NSDS bulk import functions will now return the count of imported records. They were previously not returning anything.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://splicemachine.atlassian.net/browse/DB-11789
To track the number of records imported into the DB, calling count on a large dataframe can be an expensive operation.  This change will allow retrieval of the count from the bulk import call.

## Dependencies
<!--- If this fix is dependent on code in other repos to be deployed, list that here. -->
Depends on DB PR https://github.com/splicemachine/spliceengine/pull/5356

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally in a pyspark shell by passing a dataframe to bulk import, checking that the records were inserted into the table, and checking that the count returned from the function equaled the number of records in the input dataframe.

## Changelog Inclusions

<!-- Text Entered in these sections will appear as it is written, MD formatted -->
<!-- Avoid using the # character as the first character on any line, a trim is -->
<!-- performed on each line when checking for markdown section tags -->
- NSDS bulk import functions now have integer return types providing the count of the records that were imported
<!-- If there is NO text in a section, no entries will be collected for that section -->

### Changes
NSDS bulk import functions were changed to return the count of the records imported.  Previously, they were returning nothing.
