### PR TITLE
(Feature Store UI) DBAAS-5322 - New API design for SQL data types

### DIFF
--- a/splicemachine/features/feature.py
+++ b/splicemachine/features/feature.py
@@ -1,10 +1,11 @@
 from splicemachine.features.constants import FeatureType
+from .utils.feature_utils import sql_to_datatype
 
 class Feature:
     def __init__(self, *, name, description, feature_data_type, feature_type, tags, attributes, feature_set_id=None, feature_id=None, **kwargs):
         self.name = name.upper()
         self.description = description
-        self.feature_data_type = feature_data_type
+        self.feature_data_type = sql_to_datatype(feature_data_type)
         self.feature_type = feature_type
         self.feature_set_id = feature_set_id
         self.feature_id = feature_id

--- a/splicemachine/features/utils/feature_utils.py
+++ b/splicemachine/features/utils/feature_utils.py
@@ -1,7 +1,7 @@
 from typing import Dict, Union
 
 
-def sql_to_datatype(typ: Union[str, Dict[str,str]]) -> Dict[str,str]:
+def sql_to_datatype(typ: str) -> Dict[str,str]:
     """
     Converts a SQL datatype to a DataType object
     ex:
@@ -10,7 +10,7 @@ def sql_to_datatype(typ: Union[str, Dict[str,str]]) -> Dict[str,str]:
     :param typ: the SQL data type
     :return: Dict representing a HTTP friendly datatype
     """
-    if type(typ) == dict: # Already been converted from server
+    if isinstance(typ, dict): # Already been converted from server
         return typ
     # If it's a type that has params and those params have been set
     tsplit = typ.split('(')

--- a/splicemachine/features/utils/feature_utils.py
+++ b/splicemachine/features/utils/feature_utils.py
@@ -22,7 +22,7 @@ def sql_to_datatype(typ: str) -> Dict[str,str]:
             prec, scale = params.strip(')'), None
         data_type = dict(data_type=dtype, precision=prec, scale=scale)
     # If it's a type VARCHAR that has a length
-    elif tsplit == 'VARCHAR' and len(tsplit) == 2:
+    elif tsplit[0] == 'VARCHAR' and len(tsplit) == 2:
         dtype, length = tsplit
         data_type = dict(data_type=dtype, length=length.strip(')'))
     else:

--- a/splicemachine/features/utils/feature_utils.py
+++ b/splicemachine/features/utils/feature_utils.py
@@ -1,0 +1,30 @@
+from typing import Dict, Union
+
+
+def sql_to_datatype(typ: Union[str, Dict[str,str]]) -> Dict[str,str]:
+    """
+    Converts a SQL datatype to a DataType object
+    ex:
+        sql_to_datatype('VARCHAR(50)') -> dict(data_type= 'VARCHAR',length=50)
+        sql_to_datatype('DECIMAL(10,2)') -> dict(data_type= 'DECIMAL',precision=10,scale=2)
+    :param typ: the SQL data type
+    :return: Dict representing a HTTP friendly datatype
+    """
+    if type(typ) == dict: # Already been converted from server
+        return typ
+    # If it's a type that has params and those params have been set
+    tsplit = typ.split('(')
+    if tsplit[0] in ('DECIMAL', 'FLOAT','NUMERIC') and len(tsplit) == 2:
+        dtype, params = tsplit
+        if ',' in params:
+            prec, scale = params.strip(')').split(',')
+        else:
+            prec, scale = params.strip(')'), None
+        data_type = dict(data_type=dtype, precision=prec, scale=scale)
+    # If it's a type VARCHAR that has a length
+    elif tsplit == 'VARCHAR' and len(tsplit) == 2:
+        dtype, length = tsplit
+        data_type = dict(data_type=dtype, length=length.strip(')'))
+    else:
+        data_type = dict(data_type=typ)
+    return data_type


### PR DESCRIPTION
A new structured way to send data types over the API.
ex: `VARCHAR(50)` will now send as `{'data_type':'VARCHAR':'length':50,'precision':null,'scale':null}`

## Description
The UI team needed a more structured way to send data types for the feature store that matched the format of the Cloud UI. This enables the UI to accept a data type as a JSON object that specifies the necessary parameters (validated with the UI team)

## Motivation and Context
Necessary for the feature store UI

## Dependencies
[ml-workflow](https://github.com/splicemachine/ml-workflow/compare/DBAAS-5322?expand=1)

## How Has This Been Tested?
Running against the a newly built docker image for the feature store (see below)

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/22605641/113217678-4227b380-924c-11eb-9780-0aca8a242dd5.png)

## Changelog Inclusions

<!-- Text Entered in these sections will appear as it is written, MD formatted -->
<!-- Avoid using the # character as the first character on any line, a trim is -->
<!-- performed on each line when checking for markdown section tags -->
- base feature note
  - **BREAKING** note on base feature
  - Basically whatever formatting we have here, just plain-text
	%> command example
- next feature
  - note on next feature
<!-- If there is NO text in a section, no entries will be collected for that section -->

### Additions
None
### Changes
New format for sending data types for features and feature set primary keys
### Fixes
UI needs
### Deprecated
None
### Removed
None
### Breaking Changes
None to python SDK