### PR TITLE
Dbaas 5225 - get deployments from feature or feature set

### DIFF
--- a/splicemachine/features/feature_store.py
+++ b/splicemachine/features/feature_store.py
@@ -622,16 +622,19 @@ class FeatureStore:
         make_request(self._FS_URL, Endpoints.FEATURES, RequestType.DELETE, self._basic_auth, { "name": name })
         print('Done')
 
-    def get_deployments(self, schema_name: str = None, table_name: str = None, training_set: str = None):
+    def get_deployments(self, schema_name: str = None, table_name: str = None, training_set: str = None,
+                        feature: str = None, feature_set: str = None):
         """
         Returns a list of all (or specified) available deployments
         :param schema_name: model schema name
         :param table_name: model table name
         :param training_set: training set name
+        :param feature: passing this in will return all deployments that used this feature
+        :param feature_set: passing this in will return all deployments that used this feature set
         :return: List[Deployment] the list of Deployments as dicts
         """
         return make_request(self._FS_URL, Endpoints.DEPLOYMENTS, RequestType.GET, self._basic_auth, 
-            { 'schema': schema_name, 'table': table_name, 'name': training_set })
+            { 'schema': schema_name, 'table': table_name, 'name': training_set, 'feat': feature, 'fset': feature_set})
       
     def get_training_set_features(self, training_set: str = None):
         """


### PR DESCRIPTION
Get the deployments that used either a feature or feature set

## Description
useful to understand which features / feature sets went into which deployments

## Motivation and Context
necessary for UI

## Dependencies
ml-workflow


## How Has This Been Tested?
see screenshot below
## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/22605641/113324040-a433f780-92e4-11eb-91a8-2009cad97f43.png)

## Changelog Inclusions

<!-- Text Entered in these sections will appear as it is written, MD formatted -->
<!-- Avoid using the # character as the first character on any line, a trim is -->
<!-- performed on each line when checking for markdown section tags -->
- base feature note
  - **BREAKING** note on base feature
  - Basically whatever formatting we have here, just plain-text
	%> command example
- next feature
  - note on next feature
<!-- If there is NO text in a section, no entries will be collected for that section -->

### Additions
optional feature and feature_set parameters to get deployments to filter.
### Changes
New optional parameters to `get_deployments`
### Fixes
None
### Deprecated
N/A
### Removed
N/A
### Breaking Changes
N/A