### PR TITLE
DBAAS-5189: get_feature_vector needs to return the primary keys along with the vector

### DIFF
--- a/splicemachine/features/feature_store.py
+++ b/splicemachine/features/feature_store.py
@@ -143,7 +143,8 @@ class FeatureStore:
         """
         features = [f if isinstance(f, str) else f.__dict__ for f in features]
         r = make_request(self._FS_URL, Endpoints.FEATURE_VECTOR, RequestType.POST, self._basic_auth, 
-            { "pks": return_primary_keys, "sql": return_sql }, { "features": features, "join_key_values": join_key_values })
+            params={ "pks": return_primary_keys, "sql": return_sql }, 
+            body={ "features": features, "join_key_values": join_key_values })
         return r if return_sql else pd.DataFrame(r, index=[0])
 
 

--- a/splicemachine/features/feature_store.py
+++ b/splicemachine/features/feature_store.py
@@ -131,18 +131,19 @@ class FeatureStore:
         return [Feature(**f) for f in r] if as_list else pd.DataFrame.from_dict(r)
 
     def get_feature_vector(self, features: List[Union[str, Feature]],
-                           join_key_values: Dict[str, str], return_sql=False) -> Union[str, PandasDF]:
+                           join_key_values: Dict[str, str], return_primary_keys = True, return_sql=False) -> Union[str, PandasDF]:
         """
         Gets a feature vector given a list of Features and primary key values for their corresponding Feature Sets
 
         :param features: List of str Feature names or Features
         :param join_key_values: (dict) join key values to get the proper Feature values formatted as {join_key_column_name: join_key_value}
+        :param return_primary_keys: Whether to return the Feature Set primary keys in the vector. Default True
         :param return_sql: Whether to return the SQL needed to get the vector or the values themselves. Default False
         :return: Pandas Dataframe or str (SQL statement)
         """
         features = [f if isinstance(f, str) else f.__dict__ for f in features]
         r = make_request(self._FS_URL, Endpoints.FEATURE_VECTOR, RequestType.POST, self._basic_auth, 
-            { "sql": return_sql }, { "features": features, "join_key_values": join_key_values })
+            { "pks": return_primary_keys, "sql": return_sql }, { "features": features, "join_key_values": join_key_values })
         return r if return_sql else pd.DataFrame(r, index=[0])
 
 


### PR DESCRIPTION
## Description
fs.get_feature_vector returns the vector values and the primary key(s) values
docstrings of the function have been updated to reflect the change

## Motivation and Context
Feature vectors need to return the primary keys of the associated feature sets
fixes [DBAAS-5198](https://splicemachine.atlassian.net/browse/DBAAS-5189)

## Dependencies
[ml-workflow](https://github.com/splicemachine/ml-workflow/pull/124)

## How Has This Been Tested?
tested against standalone

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/26292901/113358457-d446bf00-9313-11eb-9190-361650c4d99d.png)

## Changelog Inclusions

<!-- Text Entered in these sections will appear as it is written, MD formatted -->
<!-- Avoid using the # character as the first character on any line, a trim is -->
<!-- performed on each line when checking for markdown section tags -->
- base feature note
  - **BREAKING** note on base feature
  - Basically whatever formatting we have here, just plain-text
	%> command example
- next feature
  - note on next feature
<!-- If there is NO text in a section, no entries will be collected for that section -->

### Additions
New parameter to get_feature_vector()

### Changes

### Fixes

### Deprecated

### Removed

### Breaking Changes
