### PR TITLE
DBAAS-5311: Feature Store: Accept a JWT token for authentication

### DIFF
--- a/splicemachine/features/feature_store.py
+++ b/splicemachine/features/feature_store.py
@@ -21,7 +21,7 @@ from .utils.feature_utils import sql_to_datatype
 from .utils.drift_utils import (add_feature_plot, remove_outliers, datetime_range_split, build_feature_drift_plot, build_model_drift_plot)
 from .utils.training_utils import (dict_to_lower, _generate_training_set_history_sql,
                                    _generate_training_set_sql, _create_temp_training_view)
-from .utils.http_utils import RequestType, make_request, _get_feature_store_url, Endpoints, _get_token
+from .utils.http_utils import RequestType, make_request, _get_feature_store_url, Endpoints, _get_credentials, _get_token
 
 from .constants import SQL, FeatureType
 from .training_view import TrainingView
@@ -36,7 +36,7 @@ class FeatureStore:
         self._FS_URL = _get_feature_store_url()
         if not self._FS_URL: warnings.warn(
             "Uh Oh! FS_URL variable was not found... you should call 'fs.set_feature_store_url(<url>)' before doing anything.")
-        self._token = None
+        self._auth = None
         self.__try_auto_login()
 
     def register_splice_context(self, splice_ctx: PySpliceContext) -> None:
@@ -50,7 +50,7 @@ class FeatureStore:
         :return: List[FeatureSet] the list of Feature Sets
         """
 
-        r = make_request(self._FS_URL, Endpoints.FEATURE_SETS, RequestType.GET, self._token,
+        r = make_request(self._FS_URL, Endpoints.FEATURE_SETS, RequestType.GET, self._auth,
                          { "name": feature_set_names } if feature_set_names else None)
         return [FeatureSet(**fs) for fs in r]
 
@@ -80,7 +80,7 @@ class FeatureStore:
             * Number of pending feature sets - this will will require a new table `featurestore.pending_feature_set_deployments` and it will be a count of that
         """
 
-        r = make_request(self._FS_URL, Endpoints.SUMMARY, RequestType.GET, self._token)
+        r = make_request(self._FS_URL, Endpoints.SUMMARY, RequestType.GET, self._auth)
         return r
 
     def get_training_view(self, training_view: str) -> TrainingView:
@@ -91,7 +91,7 @@ class FeatureStore:
         :return: TrainingView
         """
 
-        r = make_request(self._FS_URL, Endpoints.TRAINING_VIEWS, RequestType.GET, self._token, { "name": training_view })
+        r = make_request(self._FS_URL, Endpoints.TRAINING_VIEWS, RequestType.GET, self._auth, { "name": training_view })
         return TrainingView(**r[0])
 
     def get_training_views(self, _filter: Dict[str, Union[int, str]] = None) -> List[TrainingView]:
@@ -103,7 +103,7 @@ class FeatureStore:
         :return: List[TrainingView]
         """
 
-        r = make_request(self._FS_URL, Endpoints.TRAINING_VIEWS, RequestType.GET, self._token)
+        r = make_request(self._FS_URL, Endpoints.TRAINING_VIEWS, RequestType.GET, self._auth)
         return [TrainingView(**tv) for tv in r]
 
     def get_training_view_id(self, name: str) -> int:
@@ -114,7 +114,7 @@ class FeatureStore:
         :return: The training view id
         """
         # return self.splice_ctx.df(SQL.get_training_view_id.format(name=name)).collect()[0][0]
-        r = make_request(self._FS_URL, Endpoints.TRAINING_VIEW_ID, RequestType.GET, self._token, { "name": name })
+        r = make_request(self._FS_URL, Endpoints.TRAINING_VIEW_ID, RequestType.GET, self._auth, { "name": name })
         return int(r)
 
     def get_features_by_name(self, names: Optional[List[str]] = None, as_list=False) -> Union[List[Feature], SparkDF]:
@@ -127,7 +127,7 @@ class FeatureStore:
         values, simply the describing metadata about the features. To create a training dataset with Feature values, see
         :py:meth:`features.FeatureStore.get_training_set` or :py:meth:`features.FeatureStore.get_feature_dataset`
         """
-        r = make_request(self._FS_URL, Endpoints.FEATURES, RequestType.GET, self._token, { "name": names })
+        r = make_request(self._FS_URL, Endpoints.FEATURES, RequestType.GET, self._auth, { "name": names })
         return [Feature(**f) for f in r] if as_list else pd.DataFrame.from_dict(r)
 
     def get_feature_vector(self, features: List[Union[str, Feature]],
@@ -142,7 +142,7 @@ class FeatureStore:
         :return: Pandas Dataframe or str (SQL statement)
         """
         features = [f if isinstance(f, str) else f.__dict__ for f in features]
-        r = make_request(self._FS_URL, Endpoints.FEATURE_VECTOR, RequestType.POST, self._token, 
+        r = make_request(self._FS_URL, Endpoints.FEATURE_VECTOR, RequestType.POST, self._auth, 
             params={ "pks": return_primary_keys, "sql": return_sql }, 
             body={ "features": features, "join_key_values": join_key_values })
         return r if return_sql else pd.DataFrame(r, index=[0])
@@ -164,7 +164,7 @@ class FeatureStore:
         :return: (str) the parameterized feature vector SQL
         """
         features = [f if isinstance(f, str) else f.__dict__ for f in features]
-        r = make_request(self._FS_URL, Endpoints.FEATURE_VECTOR_SQL, RequestType.POST, self._token, 
+        r = make_request(self._FS_URL, Endpoints.FEATURE_VECTOR_SQL, RequestType.POST, self._auth, 
             { "view": training_view }, features)
         return r
 
@@ -186,7 +186,7 @@ class FeatureStore:
         """
 
         r = make_request(self._FS_URL, Endpoints.TRAINING_VIEW_FEATURES, RequestType.GET,
-                         self._token, { "view": training_view })
+                         self._auth, { "view": training_view })
         return [Feature(**f) for f in r]
 
     def get_feature_description(self):
@@ -234,7 +234,7 @@ class FeatureStore:
         :return: Spark DF
         """
         features = [f if isinstance(f, str) else f.__dict__ for f in features]
-        r = make_request(self._FS_URL, Endpoints.TRAINING_SETS, RequestType.POST, self._token, 
+        r = make_request(self._FS_URL, Endpoints.TRAINING_SETS, RequestType.POST, self._auth, 
                         { "current": current_values_only, "label": label, "pks": return_pk_cols, "ts": return_ts_col }, 
                         { "features": features, "start_time": start_time, "end_time": end_time })
         create_time = r['metadata']['training_set_create_ts']
@@ -305,7 +305,7 @@ class FeatureStore:
 
         # # Generate the SQL needed to create the dataset
         features = [f if isinstance(f, str) else f.__dict__ for f in features] if features else None
-        r = make_request(self._FS_URL, Endpoints.TRAINING_SET_FROM_VIEW, RequestType.POST, self._token, 
+        r = make_request(self._FS_URL, Endpoints.TRAINING_SET_FROM_VIEW, RequestType.POST, self._auth, 
                         { "view": training_view, "pks": return_pk_cols, "ts": return_ts_col }, 
                         { "features": features, "start_time": start_time, "end_time": end_time })
         sql = r["sql"]
@@ -384,7 +384,7 @@ class FeatureStore:
         print(f'Registering feature set {schema_name}.{table_name} in Feature Store')
         if features:
             print(f'Registering {len(features)} features for {schema_name}.{table_name} in the Feature Store')
-        r = make_request(self._FS_URL, Endpoints.FEATURE_SETS, RequestType.POST, self._token, body=fset_dict)
+        r = make_request(self._FS_URL, Endpoints.FEATURE_SETS, RequestType.POST, self._auth, body=fset_dict)
         return FeatureSet(**r)
 
     def update_feature_metadata(self, name: str, desc: Optional[str] = None, tags: Optional[List[str]] = None,
@@ -438,7 +438,7 @@ class FeatureStore:
         f_dict = { "name": name, "description": desc or '', "feature_data_type": sql_to_datatype(feature_data_type),
                     "feature_type": feature_type, "tags": tags, "attributes": attributes }
         print(f'Registering feature {name} in Feature Store')
-        r = make_request(self._FS_URL, Endpoints.FEATURES, RequestType.POST, self._token, 
+        r = make_request(self._FS_URL, Endpoints.FEATURES, RequestType.POST, self._auth, 
             { "schema": schema_name, "table": table_name }, f_dict)
         f = Feature(**r)
         return f
@@ -470,7 +470,7 @@ class FeatureStore:
 
         tv_dict = { "name": name, "description": desc, "pk_columns": primary_keys, "ts_column": ts_col, "label_column": label_col,
                     "join_columns": join_keys, "sql_text": sql}
-        make_request(self._FS_URL, Endpoints.TRAINING_VIEWS, RequestType.POST, self._token, body=tv_dict)
+        make_request(self._FS_URL, Endpoints.TRAINING_VIEWS, RequestType.POST, self._auth, body=tv_dict)
 
     def _process_features(self, features: List[Union[Feature, str]]) -> List[Feature]:
         """
@@ -501,7 +501,7 @@ class FeatureStore:
         schema_name = schema_name.upper()
         table_name = table_name.upper()
         print(f'Deploying Feature Set {schema_name}.{table_name}')
-        make_request(self._FS_URL, Endpoints.DEPLOY_FEATURE_SET, RequestType.POST, self._token, { "schema": schema_name, "table": table_name })
+        make_request(self._FS_URL, Endpoints.DEPLOY_FEATURE_SET, RequestType.POST, self._auth, { "schema": schema_name, "table": table_name })
         print('Done')
 
     def describe_feature_sets(self) -> None:
@@ -511,7 +511,7 @@ class FeatureStore:
 
         :return: None
         """
-        r = make_request(self._FS_URL, Endpoints.FEATURE_SET_DESCRIPTIONS, RequestType.GET, self._token)
+        r = make_request(self._FS_URL, Endpoints.FEATURE_SET_DESCRIPTIONS, RequestType.GET, self._auth)
         
         print('Available feature sets')
         for desc in r:
@@ -533,7 +533,7 @@ class FeatureStore:
         schema_name = schema_name.upper()
         table_name = table_name.upper()
 
-        r = make_request(self._FS_URL, Endpoints.FEATURE_SET_DESCRIPTIONS, RequestType.GET, self._token,
+        r = make_request(self._FS_URL, Endpoints.FEATURE_SET_DESCRIPTIONS, RequestType.GET, self._auth,
                          params={'schema':schema_name, 'table':table_name})
         descs = r
         if not descs: raise SpliceMachineException(
@@ -556,7 +556,7 @@ class FeatureStore:
         :param training_view: The training view name
         :return: None
         """
-        r = make_request(self._FS_URL, Endpoints.TRAINING_VIEW_DESCRIPTIONS, RequestType.GET, self._token)
+        r = make_request(self._FS_URL, Endpoints.TRAINING_VIEW_DESCRIPTIONS, RequestType.GET, self._auth)
 
         print('Available training views')
         for desc in r:
@@ -573,7 +573,7 @@ class FeatureStore:
         :return: None
         """
 
-        r = make_request(self._FS_URL, Endpoints.TRAINING_VIEW_DESCRIPTIONS, RequestType.GET, self._token, {'name': training_view})
+        r = make_request(self._FS_URL, Endpoints.TRAINING_VIEW_DESCRIPTIONS, RequestType.GET, self._auth, {'name': training_view})
         descs = r
         if not descs: raise SpliceMachineException(f"Training view {training_view} not found. Check name and try again.")
         desc = descs[0]
@@ -611,7 +611,7 @@ class FeatureStore:
         schema_name = schema_name.upper()
         table_name = table_name.upper()
 
-        r = make_request(self._FS_URL, Endpoints.TRAINING_SET_FROM_DEPLOYMENT, RequestType.GET, self._token, 
+        r = make_request(self._FS_URL, Endpoints.TRAINING_SET_FROM_DEPLOYMENT, RequestType.GET, self._auth, 
             { "schema": schema_name, "table": table_name, "label": label, "pks": return_pk_cols, "ts": return_ts_col})
         
         metadata = r['metadata']
@@ -639,7 +639,7 @@ class FeatureStore:
             :return:
         """
         print(f"Removing feature {name}")
-        make_request(self._FS_URL, Endpoints.FEATURES, RequestType.DELETE, self._token, { "name": name })
+        make_request(self._FS_URL, Endpoints.FEATURES, RequestType.DELETE, self._auth, { "name": name })
         print('Done')
 
     def get_deployments(self, schema_name: str = None, table_name: str = None, training_set: str = None,
@@ -653,7 +653,7 @@ class FeatureStore:
         :param feature_set: passing this in will return all deployments that used this feature set
         :return: List[Deployment] the list of Deployments as dicts
         """
-        return make_request(self._FS_URL, Endpoints.DEPLOYMENTS, RequestType.GET, self._token, 
+        return make_request(self._FS_URL, Endpoints.DEPLOYMENTS, RequestType.GET, self._auth, 
             { 'schema': schema_name, 'table': table_name, 'name': training_set, 'feat': feature, 'fset': feature_set})
       
     def get_training_set_features(self, training_set: str = None):
@@ -662,7 +662,7 @@ class FeatureStore:
         :param training_set: training set name
         :return: TrainingSet as dict
         """
-        r = make_request(self._FS_URL, Endpoints.TRAINING_SET_FEATURES, RequestType.GET, self._token, 
+        r = make_request(self._FS_URL, Endpoints.TRAINING_SET_FEATURES, RequestType.GET, self._auth, 
             { 'name': training_set })
         r['features'] = [Feature(**f) for f in r['features']]
         return r
@@ -688,7 +688,7 @@ class FeatureStore:
                           " Training Sets (except ones used in an active model deployment)")
         print(f'Removing Feature Set {schema}.{table}')
         make_request(self._FS_URL, Endpoints.FEATURE_SETS,
-                     RequestType.DELETE, self._token, { "schema": schema, "table":table, "purge": purge })
+                     RequestType.DELETE, self._auth, { "schema": schema, "table":table, "purge": purge })
         print('Done')
 
     def _retrieve_model_data_sets(self, schema_name: str, table_name: str):
@@ -930,8 +930,11 @@ class FeatureStore:
     def set_feature_store_url(self, url: str):
         self._FS_URL = url
 
-    def login_fs(self, token):
-        self._token = token
+    def login_fs(self, username, password):
+        self._auth = HTTPBasicAuth(username, password)
+
+    def set_token(self, token):
+        self._auth = token
 
     def __try_auto_login(self):
         """
@@ -942,4 +945,9 @@ class FeatureStore:
         """
         token = _get_token()
         if token:
-            self.login_fs(token)
+            self.set_token(token)
+            return
+        
+        user, password = _get_credentials()
+        if user and password:
+            self.login_fs(user, password)

--- a/splicemachine/features/utils/http_utils.py
+++ b/splicemachine/features/utils/http_utils.py
@@ -45,19 +45,29 @@ class Endpoints:
     TRAINING_VIEW_ID: str = "training-view-id"
     SUMMARY: str = "summary"
 
-def make_request(url: str, endpoint: str, method: str, token: str,
+def make_request(url: str, endpoint: str, method: str, auth: str,
                  params: Optional[Dict[str, Any]] = None,
                  body: Union[Dict[str,Any], List[Any]] = None) -> Union[dict,List[dict]]:
-    if not token:
+    if not auth:
         raise Exception(
             "You have not logged into Feature Store."
-            " Please run fs.login_fs(token)"
+            " Please run fs.login_fs(username, password) "
+            " or fs.set_token(token)."
         )
     if not url:
         raise KeyError("Uh Oh! FS_URL variable was not found... you should call 'fs.set_feature_store_url(<url>)' before doing trying again.")
     url = f'{url}/{endpoint}'
     try:
-        r = RequestType.method_map[method](url, params=params, json=body, headers={'Authorization': f'Bearer {token}'})
+        if isinstance(auth, HTTPBasicAuth):
+            r = RequestType.method_map[method](url, params=params, json=body, auth=auth)
+        elif isinstance(auth, str):
+            r = RequestType.method_map[method](url, params=params, json=body, headers={'Authorization': f'Bearer {auth}'})
+        else:
+            raise Exception(
+                "Authorization credentials are not valid."
+                " Please run fs.login_fs(username, password) "
+                " or fs.set_token(token)."
+            )
     except KeyError:
         raise SpliceMachineException(f'Not a recognized HTTP method: {method}.'
                                      f'Please use one of the following: {RequestType.get_valid()}')
@@ -79,6 +89,13 @@ def _get_feature_store_url():
     """
     url = env_vars.get('FS_URL')
     return url
+
+def _get_credentials():
+    """
+    Returns the username and password of the user if stored in env variables
+    :return: str, str
+    """
+    return env_vars.get('SPLICE_JUPYTER_USER'), env_vars.get('SPLICE_JUPYTER_PASSWORD')
 
 def _get_token():
     """

--- a/splicemachine/features/utils/http_utils.py
+++ b/splicemachine/features/utils/http_utils.py
@@ -45,19 +45,19 @@ class Endpoints:
     TRAINING_VIEW_ID: str = "training-view-id"
     SUMMARY: str = "summary"
 
-def make_request(url: str, endpoint: str, method: str, auth: HTTPBasicAuth,
+def make_request(url: str, endpoint: str, method: str, token: str,
                  params: Optional[Dict[str, Any]] = None,
                  body: Union[Dict[str,Any], List[Any]] = None) -> Union[dict,List[dict]]:
-    if not auth:
+    if not token:
         raise Exception(
-            "You have not logged into Feature Store director."
-            " Please run fs.login_fs(username, password)"
+            "You have not logged into Feature Store."
+            " Please run fs.login_fs(token)"
         )
     if not url:
         raise KeyError("Uh Oh! FS_URL variable was not found... you should call 'fs.set_feature_store_url(<url>)' before doing trying again.")
     url = f'{url}/{endpoint}'
     try:
-        r = RequestType.method_map[method](url, params=params, json=body, auth=auth)
+        r = RequestType.method_map[method](url, params=params, json=body, headers={'Authorization': f'Bearer {token}'})
     except KeyError:
         raise SpliceMachineException(f'Not a recognized HTTP method: {method}.'
                                      f'Please use one of the following: {RequestType.get_valid()}')
@@ -80,10 +80,10 @@ def _get_feature_store_url():
     url = env_vars.get('FS_URL')
     return url
 
-def _get_credentials():
+def _get_token():
     """
-    Returns the username and password of the user if stored in env variables
+    Returns the JWT token of the user if stored in env variables
 
-    :return: str, str
+    :return: str
     """
-    return env_vars.get('SPLICE_JUPYTER_USER'), env_vars.get('SPLICE_JUPYTER_PASSWORD')
+    return env_vars.get('SPLICE_JUPYTER_TOKEN')


### PR DESCRIPTION
## Description
pysplice can send either basic auth or JWT token to feature store

## Motivation and Context
Necessary for single sign-on
Fixes [DBAAS-5311](https://splicemachine.atlassian.net/browse/DBAAS-5311)

## Dependencies
N/A

## How Has This Been Tested?
Tested against standalone db

## Screenshots (if appropriate):

## Changelog Inclusions

<!-- Text Entered in these sections will appear as it is written, MD formatted -->
<!-- Avoid using the # character as the first character on any line, a trim is -->
<!-- performed on each line when checking for markdown section tags -->
- base feature note
  - **BREAKING** note on base feature
  - Basically whatever formatting we have here, just plain-text
	%> command example
- next feature
  - note on next feature
<!-- If there is NO text in a section, no entries will be collected for that section -->

### Additions
Allows for setting authorization to JWT token

### Changes

### Fixes

### Deprecated

### Removed

### Breaking Changes
