### PR TITLE
Dbaas 5194: Register training sets

### DIFF
--- a/splicemachine/features/feature_store.py
+++ b/splicemachine/features/feature_store.py
@@ -998,11 +998,11 @@ class FeatureStore:
         schema_name = schema_name.upper()
         table_name = table_name.upper()
 
-        metadata = self._retrieve_training_set_metadata_from_deployement(schema_name, table_name)
-        if not metadata:
-            raise SpliceMachineException(f"Could not find deployment for model table {schema_name}.{table_name}") from None
+        metadata = make_request(self._FS_URL, Endpoints.TRAINING_SET_FROM_DEPLOYMENT, RequestType.GET,
+                                self._auth, params={ "schema": schema_name, "table": table_name})['metadata']
+
         training_set_df, model_table_df = self._retrieve_model_data_sets(schema_name, table_name)
-        features = metadata['FEATURES'].split(',')
+        features = metadata['features']
         build_feature_drift_plot(features, training_set_df, model_table_df)
 
 

--- a/splicemachine/features/feature_store.py
+++ b/splicemachine/features/feature_store.py
@@ -1002,7 +1002,7 @@ class FeatureStore:
                                 self._auth, params={ "schema": schema_name, "table": table_name})['metadata']
 
         training_set_df, model_table_df = self._retrieve_model_data_sets(schema_name, table_name)
-        features = metadata['features']
+        features = metadata['features'].split(',')
         build_feature_drift_plot(features, training_set_df, model_table_df)
 
 

--- a/splicemachine/features/training_set.py
+++ b/splicemachine/features/training_set.py
@@ -17,11 +17,17 @@ class TrainingSet:
                  features: List[Feature],
                  create_time: datetime,
                  start_time: Optional[datetime] = None,
-                 end_time: Optional[datetime] = None
+                 end_time: Optional[datetime] = None,
+                 training_set_id: Optional[int] = None,
+                 training_set_version: Optional[int] = None,
+                 training_set_name: Optional[str] = None
                  ):
         self.training_view = training_view
         self.features = features
         self.create_time = create_time
+        self.training_set_id = training_set_id
+        self.training_set_version = training_set_version
+        self.training_set_name = training_set_name
         self.start_time = start_time or datetime(year=1900,month=1,day=1) # Saw problems with spark handling datetime.min
         self.end_time = end_time or datetime.today()
 
@@ -36,13 +42,16 @@ class TrainingSet:
         if mlflow_ctx.active_run():
             print("There is an active mlflow run, your training set will be logged to that run.")
             try:
-                mlflow_ctx.lp("splice.feature_store.training_set",self.training_view.name)
                 mlflow_ctx.lp("splice.feature_store.training_view_id",self.training_view.view_id)
                 mlflow_ctx.lp("splice.feature_store.training_set_start_time",str(self.start_time))
                 mlflow_ctx.lp("splice.feature_store.training_set_end_time",str(self.end_time))
                 mlflow_ctx.lp("splice.feature_store.training_set_create_time",str(self.create_time))
                 mlflow_ctx.lp("splice.feature_store.training_set_num_features", len(self.features))
                 mlflow_ctx.lp("splice.feature_store.training_set_label", self.training_view.label_column)
+                if self.training_set_id and self.training_set_version and self.training_set_name:
+                    mlflow_ctx.lp("splice.feature_store.training_set_id",self.training_set_id)
+                    mlflow_ctx.lp("splice.feature_store.training_set_version",self.training_set_version)
+                    mlflow_ctx.lp("splice.feature_store.training_set_name",self.training_set_name)
                 for i,f in enumerate(self.features):
                     mlflow_ctx.lp(f'splice.feature_store.training_set_feature_{i}',f.name)
             except:

--- a/splicemachine/features/utils/http_utils.py
+++ b/splicemachine/features/utils/http_utils.py
@@ -42,6 +42,7 @@ class Endpoints:
     TRAINING_SET_FEATURES: str = "training-set-features"
     TRAINING_SET_FROM_DEPLOYMENT: str = "training-set-from-deployment"
     TRAINING_SET_FROM_VIEW: str = "training-set-from-view"
+    TRAINING_SET_BY_NAME: str = 'training-set-by-name'
     TRAINING_VIEWS: str = "training-views"
     TRAINING_VIEW_DETAILS: str = "training-view-details"
     TRAINING_VIEW_FEATURES: str = "training-view-features"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This adds the ability for users to save and version training sets, and recreate them later by name and version.

## Motivation and Context
This is very important for users using the featurestore outside of the splice MLManager system. It's important to be able to "save" an instance of a training set for reproducibility. We were already doing this automatically with mlflow. But if users aren't using our mlflow then they need a way to do it.

## Dependencies
[ml-workflow](https://github.com/splicemachine/ml-workflow/pull/138)

## How Has This Been Tested?
Ran the demo notebooks on current release, ran the upgrade script, upgraded the featurestore and bobby pods, and reran the demo.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/22605641/115485851-770fa080-a223-11eb-9225-0ab25a6de658.png)

## Changelog Inclusions

<!-- Text Entered in these sections will appear as it is written, MD formatted -->
<!-- Avoid using the # character as the first character on any line, a trim is -->
<!-- performed on each line when checking for markdown section tags -->
- base feature note
  - **BREAKING** note on base feature
  - Basically whatever formatting we have here, just plain-text
	%> command example
- next feature
  - note on next feature
<!-- If there is NO text in a section, no entries will be collected for that section -->

### Additions
Adds the ability for users to save and version training sets, and recreate them later by name and version.

### Changes
A new Training_Set_Instance table for versioning training sets

### Fixes
Fix to `model_feature_drift` where it was running a client side SQL statement that was broken. Moved that to a call to the client which fixes the issue and makes it run faster.

### Deprecated

### Removed

### Breaking Changes
