### PR TITLE
Dbaas 5440 - Support training sets as pandas dataframes

### DIFF
--- a/splicemachine/features/feature_store.py
+++ b/splicemachine/features/feature_store.py
@@ -1,6 +1,7 @@
+from sys import stderr
 from typing import List, Dict, Optional, Union
 from datetime import datetime
-import re
+import json
 
 from IPython.display import display
 import pandas as pd
@@ -18,6 +19,7 @@ from splicemachine.spark import PySpliceContext
 from splicemachine.features import Feature, FeatureSet
 from .training_set import TrainingSet
 from .utils.drift_utils import build_feature_drift_plot, build_model_drift_plot
+from .utils.training_utils import ReturnType
 from .pipelines import FeatureAggregation
 from .utils.http_utils import RequestType, make_request, _get_feature_store_url, Endpoints, _get_credentials, _get_token
 
@@ -235,7 +237,8 @@ class FeatureStore:
 
     def get_training_set(self, features: Union[List[Feature], List[str]], current_values_only: bool = False,
                          start_time: datetime = None, end_time: datetime = None, label: str = None, return_pk_cols: bool = False, 
-                         return_ts_col: bool = False, return_sql: bool = False, save_as: str = None) -> SparkDF or str:
+                         return_ts_col: bool = False, return_type: str = None,
+                         return_sql: bool = False, save_as: str = None) -> SparkDF or str:
         """
         Gets a set of feature values across feature sets that is not time dependent (ie for non time series clustering).
         This feature dataset will be treated and tracked implicitly the same way a training_dataset is tracked from
@@ -274,6 +277,9 @@ class FeatureStore:
             (but not others in the future, unless this label is again specified).
         :param return_pk_cols: bool Whether or not the returned sql should include the primary key column(s)
         :param return_ts_cols: bool Whether or not the returned sql should include the timestamp column
+        :param return_type: How the data should be returned. If not specified, a Spark DF will be returned.
+            Available arguments are: 'spark', 'pandas', 'json', 'sql'
+            sql will return the SQL necessary to generate the dataframe
         :param save_as: Whether or not to save this Training Set (metadata) in the feature store for reproducibility. This
             enables you to version and persist the metadata for a training set of a specific model development. If you are
             using the Splice Machine managed MLFlow Service, this will be fully automated and managed for you upon model deployment,
@@ -283,10 +289,19 @@ class FeatureStore:
             to reproduce the identical training set.
         :return: Spark DF or SQL statement necessary to generate the Training Set
         """
+
+        # ~ Backwards Compatability ~
+        if return_sql:
+            print("Deprecated Parameter 'return_sql'. Use return_type='sql' ", file=stderr)
+            return_type = 'sql'
+
+        if return_type not in ReturnType.get_valid():
+            raise SpliceMachineException(f'Return type must be one of {ReturnType.get_valid()}')
+
         features = [f if isinstance(f, str) else f.__dict__ for f in features]
         r = make_request(self._FS_URL, Endpoints.TRAINING_SETS, RequestType.POST, self._auth, 
                         params={ "current": current_values_only, "label": label, "pks": return_pk_cols, "ts": return_ts_col,
-                          'save_as':save_as },
+                          'save_as':save_as, 'return_type': ReturnType.map_to_request(return_type)},
                         body={ "features": features, "start_time": start_time, "end_time": end_time})
         create_time = r['metadata']['training_set_create_ts']
         start_time = r['metadata']['training_set_start_ts']
@@ -307,14 +322,23 @@ class FeatureStore:
         # If the user isn't getting historical values, that means there isn't really a start_time, as the user simply
         # wants the most up to date values of each feature. So we set start_time to end_time (which is datetime.today)
 
-        if self.mlflow_ctx and not return_sql:
+        if self.mlflow_ctx and return_type != 'sql':
             # These will only exist if the user called "save_as" otherwise they will be None
             training_set_id = r['metadata'].get('training_set_id')
             training_set_version = r['metadata'].get('training_set_version')
             self.link_training_set_to_mlflow(features, create_time, start_time, end_time, tvw,
                                              training_set_id=training_set_id,
                                              training_set_version=training_set_version,training_set_name=save_as)
-        return sql if return_sql else self.splice_ctx.df(sql)
+
+        if return_type == ReturnType.SQL:
+            return sql
+        elif return_type == ReturnType.PANDAS:
+            return pd.DataFrame(dict(r['data']))
+        elif return_type == ReturnType.JSON:
+            return json.dumps(dict(r['data']))
+        else:
+            return self.splice_ctx.df(sql)
+        # return sql if return_sql else self.splice_ctx.df(sql)
 
     def get_training_set_by_name(self, name, version: int = None, return_pk_cols: bool = False,
                                  return_ts_col: bool = False, return_sql = False):
@@ -352,7 +376,7 @@ class FeatureStore:
     def get_training_set_from_view(self, training_view: str, features: Union[List[Feature], List[str]] = None,
                                    start_time: Optional[datetime] = None, end_time: Optional[datetime] = None,
                                    return_pk_cols: bool = False, return_ts_col: bool = False, return_sql: bool = False,
-                                   save_as: str = None) -> SparkDF or str:
+                                   return_type: str = None, save_as: str = None) -> SparkDF or str:
         """
         Returns the training set as a Spark Dataframe from a Training View. When a user calls this function (assuming they have registered
         the feature store with mlflow using :py:meth:`~mlflow.register_feature_store` )
@@ -392,6 +416,9 @@ class FeatureStore:
         :param return_pk_cols: bool Whether or not the returned sql should include the primary key column(s)
         :param return_ts_cols: bool Whether or not the returned sql should include the timestamp column
         :param return_sql: (Optional[bool]) Return the SQL statement (str) instead of the Spark DF. Defaults False
+        :param return_type: How the data should be returned. If not specified, a Spark DF will be returned.
+            Available arguments are: 'spark', 'pandas', 'json', 'sql'
+            sql will return the SQL necessary to generate the dataframe
         :param save_as: Whether or not to save this Training Set (metadata) in the feature store for reproducibility. This
             enables you to version and persist the metadata for a training set of a specific model development. If you are
             using the Splice Machine managed MLFlow Service, this will be fully automated and managed for you upon model deployment,
@@ -402,11 +429,21 @@ class FeatureStore:
         :return: Optional[SparkDF, str] The Spark dataframe of the training set or the SQL that is used to generate it (for debugging)
         """
 
+        # ~ Backwards Compatability ~
+        if return_sql:
+            print("Deprecated Parameter 'return_sql'. Use return_type='sql' ", file=stderr)
+            return_type = 'sql'
+
+        if return_type not in ReturnType.get_valid():
+            raise SpliceMachineException(f'Return type must be one of {ReturnType.get_valid()}')
+
         # Generate the SQL needed to create the dataset
         features = [f if isinstance(f, str) else f.__dict__ for f in features] if features else None
-        r = make_request(self._FS_URL, Endpoints.TRAINING_SET_FROM_VIEW, RequestType.POST, self._auth, 
-                        { "view": training_view, "pks": return_pk_cols, "ts": return_ts_col, 'save_as': save_as },
-                        { "features": features, "start_time": start_time, "end_time": end_time })
+        r = make_request(self._FS_URL, Endpoints.TRAINING_SET_FROM_VIEW, RequestType.POST, self._auth,
+                         params={ "view": training_view, "pks": return_pk_cols, "ts": return_ts_col,
+                                 'save_as': save_as, 'return_type': ReturnType.map_to_request(return_type) },
+                         body={"features": features, "start_time": start_time, "end_time": end_time },
+                         headers={"Accept-Encoding": "gzip"})
         sql = r["sql"]
         tvw = TrainingView(**r["training_view"])
         features = [Feature(**f) for f in r["features"]]
@@ -422,7 +459,15 @@ class FeatureStore:
                                              training_set_id=training_set_id,
                                              training_set_version=training_set_version, training_set_name=save_as)
 
-        return sql if return_sql else self.splice_ctx.df(sql)
+        if return_type == ReturnType.SQL:
+            return sql
+        elif return_type == ReturnType.PANDAS:
+            return pd.DataFrame(dict(r['data']))
+        elif return_type == ReturnType.JSON:
+            return json.dumps(dict(r['data']))
+        else:
+            return self.splice_ctx.df(sql)
+        # return sql if return_sql else self.splice_ctx.df(sql)
 
     def list_training_sets(self) -> Dict[str, Optional[str]]:
         """

--- a/splicemachine/features/feature_store.py
+++ b/splicemachine/features/feature_store.py
@@ -15,11 +15,11 @@ from pyspark.ml.feature import StringIndexer, VectorAssembler
 
 from splicemachine import SpliceMachineException
 from splicemachine.features.utils.feature_utils import sql_to_datatype
-from splicemachine.spark import PySpliceContext
+from splicemachine.spark import PySpliceContext, ExtPySpliceContext
 from splicemachine.features import Feature, FeatureSet
 from .training_set import TrainingSet
 from .utils.drift_utils import build_feature_drift_plot, build_model_drift_plot
-from .utils.training_utils import ReturnType
+from .utils.training_utils import ReturnType, _format_training_set_output
 from .pipelines import FeatureAggregation
 from .utils.http_utils import RequestType, make_request, _get_feature_store_url, Endpoints, _get_credentials, _get_token
 
@@ -40,6 +40,9 @@ class FeatureStore:
         self.__try_auto_login()
 
     def register_splice_context(self, splice_ctx: PySpliceContext) -> None:
+        if not (isinstance(splice_ctx, PySpliceContext) or isinstance(splice_ctx, ExtPySpliceContext)):
+            raise SpliceMachineException(f'Splice Context must be of type PySpliceContext or ExtPySpliceContext but is'
+                                         f'of type {type(splice_ctx)}')
         self.splice_ctx = splice_ctx
 
     def get_feature_sets(self, feature_set_names: List[str] = None) -> List[FeatureSet]:
@@ -237,7 +240,7 @@ class FeatureStore:
 
     def get_training_set(self, features: Union[List[Feature], List[str]], current_values_only: bool = False,
                          start_time: datetime = None, end_time: datetime = None, label: str = None, return_pk_cols: bool = False, 
-                         return_ts_col: bool = False, return_type: str = None,
+                         return_ts_col: bool = False, return_type: str = 'spark',
                          return_sql: bool = False, save_as: str = None) -> SparkDF or str:
         """
         Gets a set of feature values across feature sets that is not time dependent (ie for non time series clustering).
@@ -330,18 +333,11 @@ class FeatureStore:
                                              training_set_id=training_set_id,
                                              training_set_version=training_set_version,training_set_name=save_as)
 
-        if return_type == ReturnType.SQL:
-            return sql
-        elif return_type == ReturnType.PANDAS:
-            return pd.DataFrame(dict(r['data']))
-        elif return_type == ReturnType.JSON:
-            return json.dumps(dict(r['data']))
-        else:
-            return self.splice_ctx.df(sql)
-        # return sql if return_sql else self.splice_ctx.df(sql)
+
+        return _format_training_set_output(response=r, return_type=return_type, splice_ctx=self.splice_ctx)
 
     def get_training_set_by_name(self, name, version: int = None, return_pk_cols: bool = False,
-                                 return_ts_col: bool = False, return_sql = False):
+                                 return_ts_col: bool = False, return_sql = False, return_type: str = 'spark'):
         """
         Returns a Spark DF (or SQL) of an EXISTING Training Set (one that was saved with the save_as parameter in
         :py:meth:`~fs.get_training_set` or :py:meth:`~fs.get_training_set_from_view`. This is useful if you've deployed
@@ -351,12 +347,24 @@ class FeatureStore:
         :param version: The version of this training set. If not set, it will grab the newest version
         :param return_pk_cols: bool Whether or not the returned sql should include the primary key column(s)
         :param return_ts_cols: bool Whether or not the returned sql should include the timestamp column
-        :param return_sql: (Optional[bool]) Return the SQL statement (str) instead of the Spark DF. Defaults False
+        :param return_sql: [DEPRECATED] (Optional[bool]) Return the SQL statement (str) instead of the Spark DF. Defaults False
+        :param return_type: How the data should be returned. If not specified, a Spark DF will be returned.
+            Available arguments are: 'spark', 'pandas', 'json', 'sql'
+            sql will return the SQL necessary to generate the dataframe
         :return: Spark DF or SQL
         """
 
+        # ~ Backwards Compatability ~
+        if return_sql:
+            print("Deprecated Parameter 'return_sql'. Use return_type='sql' ", file=stderr)
+            return_type = 'sql'
+
+        if return_type not in ReturnType.get_valid():
+            raise SpliceMachineException(f'Return type must be one of {ReturnType.get_valid()}')
+
         r = make_request(self._FS_URL, Endpoints.TRAINING_SET_BY_NAME, RequestType.GET, self._auth,
-                        params={ "name": name, "version": version, "pks": return_pk_cols, "ts": return_ts_col})
+                        params={ "name": name, "version": version, "pks": return_pk_cols, "ts": return_ts_col,
+                                 'return_type': ReturnType.map_to_request(return_type)})
         sql = r["sql"]
         tvw = TrainingView(**r["training_view"])
         features = [Feature(**f) for f in r["features"]]
@@ -371,12 +379,12 @@ class FeatureStore:
                                              training_set_id=training_set_id,
                                              training_set_version=version, training_set_name=name)
 
-        return sql if return_sql else self.splice_ctx.df(sql)
+        return _format_training_set_output(response=r, return_type=return_type, splice_ctx=self.splice_ctx)
 
     def get_training_set_from_view(self, training_view: str, features: Union[List[Feature], List[str]] = None,
                                    start_time: Optional[datetime] = None, end_time: Optional[datetime] = None,
                                    return_pk_cols: bool = False, return_ts_col: bool = False, return_sql: bool = False,
-                                   return_type: str = None, save_as: str = None) -> SparkDF or str:
+                                   return_type: str = 'spark', save_as: str = None) -> SparkDF or str:
         """
         Returns the training set as a Spark Dataframe from a Training View. When a user calls this function (assuming they have registered
         the feature store with mlflow using :py:meth:`~mlflow.register_feature_store` )
@@ -415,7 +423,7 @@ class FeatureStore:
 
         :param return_pk_cols: bool Whether or not the returned sql should include the primary key column(s)
         :param return_ts_cols: bool Whether or not the returned sql should include the timestamp column
-        :param return_sql: (Optional[bool]) Return the SQL statement (str) instead of the Spark DF. Defaults False
+        :param return_sql: [DEPRECATED] (Optional[bool]) Return the SQL statement (str) instead of the Spark DF. Defaults False
         :param return_type: How the data should be returned. If not specified, a Spark DF will be returned.
             Available arguments are: 'spark', 'pandas', 'json', 'sql'
             sql will return the SQL necessary to generate the dataframe
@@ -459,15 +467,7 @@ class FeatureStore:
                                              training_set_id=training_set_id,
                                              training_set_version=training_set_version, training_set_name=save_as)
 
-        if return_type == ReturnType.SQL:
-            return sql
-        elif return_type == ReturnType.PANDAS:
-            return pd.DataFrame(dict(r['data']))
-        elif return_type == ReturnType.JSON:
-            return json.dumps(dict(r['data']))
-        else:
-            return self.splice_ctx.df(sql)
-        # return sql if return_sql else self.splice_ctx.df(sql)
+        return _format_training_set_output(response=r, return_type=return_type, splice_ctx=self.splice_ctx)
 
     def list_training_sets(self) -> Dict[str, Optional[str]]:
         """
@@ -757,8 +757,9 @@ class FeatureStore:
     def set_feature_description(self):
         raise NotImplementedError
 
-    def get_training_set_from_deployment(self, schema_name: str, table_name: str, label: str = None, 
-                                        return_pk_cols: bool = False, return_ts_col: bool = False):
+    def get_training_set_from_deployment(self, schema_name: str, table_name: str, label: str = None,
+                                         return_pk_cols: bool = False, return_ts_col: bool = False,
+                                         return_type: str = 'spark'):
         """
         Reads Feature Store metadata to rebuild orginal training data set used for the given deployed model.
 
@@ -770,17 +771,24 @@ class FeatureStore:
             (but not others in the future, unless this label is again specified).
         :param return_pk_cols: bool Whether or not the returned sql should include the primary key column(s)
         :param return_ts_cols: bool Whether or not the returned sql should include the timestamp column
+        :param return_type: How the data should be returned. If not specified, a Spark DF will be returned.
+            Available arguments are: 'spark', 'pandas', 'json', 'sql'
+            sql will return the SQL necessary to generate the dataframe
         :return: SparkDF the Training Frame
         """
         # database stores object names in upper case
         schema_name = schema_name.upper()
         table_name = table_name.upper()
 
+
+        if return_type not in ReturnType.get_valid():
+            raise SpliceMachineException(f'Return type must be one of {ReturnType.get_valid()}')
+
         r = make_request(self._FS_URL, Endpoints.TRAINING_SET_FROM_DEPLOYMENT, RequestType.GET, self._auth, 
-            { "schema": schema_name, "table": table_name, "label": label, "pks": return_pk_cols, "ts": return_ts_col})
+            { "schema": schema_name, "table": table_name, "label": label,
+              "pks": return_pk_cols, "ts": return_ts_col, 'return_type': ReturnType.map_to_request(return_type)})
         
         metadata = r['metadata']
-        sql = r['sql']
 
         tv_name = metadata['name']
         start_time = metadata['training_set_start_ts']
@@ -792,7 +800,8 @@ class FeatureStore:
 
         if self.mlflow_ctx:
             self.link_training_set_to_mlflow(features, create_time, start_time, end_time, tv)
-        return self.splice_ctx.df(sql)
+
+        return _format_training_set_output(response=r, return_type=return_type, splice_ctx=self.splice_ctx)
 
     def remove_feature(self, name: str):
         """

--- a/splicemachine/features/utils/http_utils.py
+++ b/splicemachine/features/utils/http_utils.py
@@ -57,7 +57,8 @@ class Endpoints:
 
 def make_request(url: str, endpoint: str, method: str, auth: str,
                  params: Optional[Dict[str, Any]] = None,
-                 body: Union[Dict[str,Any], List[Any]] = None) -> Union[dict,List[dict]]:
+                 body: Union[Dict[str,Any], List[Any]] = None,
+                 headers: Dict[str,str] = None) -> Union[dict,List[dict]]:
     if not auth:
         raise Exception(
             "You have not logged into Feature Store."
@@ -69,9 +70,11 @@ def make_request(url: str, endpoint: str, method: str, auth: str,
     url = f'{url}/{endpoint}'
     try:
         if isinstance(auth, HTTPBasicAuth):
-            r = RequestType.method_map[method](url, params=params, json=body, auth=auth)
+            r = RequestType.method_map[method](url, params=params, json=body, auth=auth, headers=headers)
         elif isinstance(auth, str):
-            r = RequestType.method_map[method](url, params=params, json=body, headers={'Authorization': f'Bearer {auth}'})
+            headers = headers or {}
+            headers['Authorization'] = f'Bearer {auth}'
+            r = RequestType.method_map[method](url, params=params, json=body, headers=headers)
         else:
             raise Exception(
                 "Authorization credentials are not valid."

--- a/splicemachine/features/utils/training_utils.py
+++ b/splicemachine/features/utils/training_utils.py
@@ -7,6 +7,32 @@ from splicemachine.features.training_view import TrainingView
 A set of utility functions for creating Training Set SQL 
 """
 
+class ReturnType:
+    """
+    An enum class for available Training Set return types
+    """
+    SQL = 'sql'
+    SPARK = 'spark'
+    PANDAS = 'pandas'
+    JSON = 'json'
+
+    @staticmethod
+    def get_valid():
+        return (ReturnType.SQL, ReturnType.PANDAS, ReturnType.SPARK, ReturnType.JSON)
+    @staticmethod
+    def map_to_request(rt: str) -> str:
+        """
+        Maps a users requested type to the proper type for the REST api request
+        :param rt: The return type (sql, json, pandas, spark)
+        :return: The proper return type for the REST api
+        """
+        if rt in (ReturnType.PANDAS, ReturnType.JSON):
+            return ReturnType.JSON
+        elif rt not in ReturnType.get_valid():
+            return ''
+        return rt
+
+
 def clean_df(df, cols):
     for old, new in zip(df.columns, cols):
         df = df.withColumnRenamed(old, new)

--- a/splicemachine/features/utils/training_utils.py
+++ b/splicemachine/features/utils/training_utils.py
@@ -1,7 +1,8 @@
 from splicemachine import SpliceMachineException
-from typing import List
-from splicemachine.features import Feature, FeatureSet
-from splicemachine.features.training_view import TrainingView
+from typing import Dict, Any, Union
+from splicemachine.spark import PySpliceContext, ExtPySpliceContext
+import pandas as pd
+import json
 
 """
 A set of utility functions for creating Training Set SQL 
@@ -18,7 +19,7 @@ class ReturnType:
 
     @staticmethod
     def get_valid():
-        return (ReturnType.SQL, ReturnType.PANDAS, ReturnType.SPARK, ReturnType.JSON)
+        return {ReturnType.SQL, ReturnType.PANDAS, ReturnType.SPARK, ReturnType.JSON}
     @staticmethod
     def map_to_request(rt: str) -> str:
         """
@@ -33,155 +34,37 @@ class ReturnType:
         return rt
 
 
-def clean_df(df, cols):
-    for old, new in zip(df.columns, cols):
-        df = df.withColumnRenamed(old, new)
-    return df
-
-def dict_to_lower(dict):
+def _format_training_set_output(response: Dict[str, Any], return_type: str,
+                                splice_ctx: Union[PySpliceContext, ExtPySpliceContext]):
     """
-    Converts a dictionary to all lowercase keys
+    Calls to get_training_set, get_training_set_from_view, get_training_set_from_deployment, get_training_set_by_name
+    have an optional return_type parameter. This will change what is returned.
 
-    :param dict: The dictionary
-    :return: The lowercased dictionary
+    json -> Return the raw response
+    pandas -> Convert raw response to pandas dataframe and return that
+    spark -> Run the Training Set SQL via the NSDS and return the Spark DF
+    sql -> Return the SQL
+
+    :param response: The response from the call to the API
+    :return: The training set in the form requested
     """
-    return {i.lower(): dict[i] for i in dict}
 
-
-def _get_anchor_feature_set(features: List[Feature], feature_sets: List[FeatureSet]) -> FeatureSet:
-    """
-    From a dataframe of feature set rows, where each row has columns feature_set_id, schema_name, table_name
-    and pk_cols where pk_cols is a pipe delimited string of Primary Key column names,
-    this function finds which row has the superset of all primary key columns, raising an exception if none exist
-
-    :param fset_keys: Pandas Dataframe containing FEATURE_SET_ID, SCHEMA_NAME, TABLE_NAME, and PK_COLUMNS, which
-    is a | delimited string of column names
-    :return: FeatureSet
-    :raise: SpliceMachineException
-    """
-    # Get the Feature Set with the maximum number of primary key columns as the anchor
-    anchor_fset = feature_sets[0]
-
-    for fset in feature_sets:
-        if len(fset.pk_columns) > len(anchor_fset.pk_columns):
-            anchor_fset = fset
-
-    # If Features are requested that come from Feature Sets that cannot be joined to our anchor, we will raise an
-    # Exception and let the user know
-    bad_features = []
-    all_pk_cols = set(anchor_fset.pk_columns)
-    for fset in feature_sets:
-        if not set(fset.pk_columns).issubset(all_pk_cols):
-            bad_features += [f.name for f in features if f.feature_set_id == fset.feature_set_id]
-
-    if bad_features:
-        raise SpliceMachineException(f"The provided features do not have a common join key."
-                                     f"Remove features {bad_features} from your request")
-
-    return anchor_fset
-
-
-def _generate_training_set_history_sql(tvw: TrainingView, features: List[Feature],
-                                       feature_sets: List[FeatureSet], start_time=None, end_time=None) -> str:
-    """
-    Generates the SQL query for creating a training set from a TrainingView and a List of Features.
-    This performs the coalesces necessary to aggregate Features over time in a point-in-time consistent way
-
-    :param tvw: The TrainingView
-    :param features: List[Feature] The group of Features desired to be returned
-    :param feature_sets: List[FeatureSets] the group of all Feature Sets of which Features are being selected
-    :return: str the SQL necessary to execute
-    """
-    # SELECT clause
-    sql = 'SELECT '
-    for pkcol in tvw.pk_columns:  # Select primary key column(s)
-        sql += f'\n\tctx.{pkcol},'
-
-    sql += f'\n\tctx.{tvw.ts_column}, '  # Select timestamp column
-
-    # TODO: ensure these features exist and fail gracefully if not
-    for feature in features:
-        sql += f'\n\tCOALESCE(fset{feature.feature_set_id}.{feature.name},fset{feature.feature_set_id}h.{feature.name}) {feature.name},'  # Collect all features over time
-
-    # Select the optional label col
-    if tvw.label_column:
-        sql += f'\n\tctx.{tvw.label_column}'
+    if return_type == ReturnType.SQL:
+        return response['sql']
+    elif return_type == ReturnType.PANDAS:
+        try:
+            return pd.DataFrame(dict(json.loads(response['data'])))
+        except Exception as e:
+            raise SpliceMachineException(f"There was an issue converting the response data to a Pandas dataframe. Consider"
+                                         f" setting return_type to 'json' to get the raw data, or 'sql' "
+                                         f"to the SQL that was generated. Error from pandas: {str(e)} ")
+    elif return_type == ReturnType.JSON:
+        return response['data']
     else:
-        sql = sql.rstrip(',')
-
-    # FROM clause
-    sql += f'\nFROM ({tvw.view_sql}) ctx '
-
-    # JOIN clause
-    for fset in feature_sets:
-        # Join Feature Set
-        sql += f'\nLEFT OUTER JOIN {fset.schema_name}.{fset.table_name} fset{fset.feature_set_id} \n\tON '
-        for pkcol in fset.pk_columns:
-            sql += f'fset{fset.feature_set_id}.{pkcol}=ctx.{pkcol} AND '
-        sql += f' ctx.{tvw.ts_column} >= fset{fset.feature_set_id}.LAST_UPDATE_TS '
-
-        # Join Feature Set History
-        sql += f'\nLEFT OUTER JOIN {fset.schema_name}.{fset.table_name}_history fset{fset.feature_set_id}h \n\tON '
-        for pkcol in fset.pk_columns:
-            sql += f' fset{fset.feature_set_id}h.{pkcol}=ctx.{pkcol} AND '
-        sql += f' ctx.{tvw.ts_column} >= fset{fset.feature_set_id}h.ASOF_TS AND ctx.{tvw.ts_column} < fset{fset.feature_set_id}h.UNTIL_TS'
-
-    # WHERE clause on optional start and end times
-    if start_time or end_time:
-        sql += '\nWHERE '
-        if start_time:
-            sql += f"\n\tctx.{tvw.ts_column} >= '{str(start_time)}' AND"
-        if end_time:
-            sql += f"\n\tctx.{tvw.ts_column} <= '{str(end_time)}'"
-        sql = sql.rstrip('AND')
-    return sql
-
-
-def _generate_training_set_sql(features: List[Feature], feature_sets: List[FeatureSet]) -> str:
-    """
-    Generates the SQL query for creating a training set from a List of Features (NO TrainingView).
-
-    :param features: List[Feature] The group of Features desired to be returned
-    :param feature_sets: List of Feature Sets
-    :return: str the SQL necessary to execute
-    """
-    anchor_fset: FeatureSet = _get_anchor_feature_set(features, feature_sets)
-    alias = f'fset{anchor_fset.feature_set_id}'  # We use this a lot for joins
-    anchor_fset_schema = f'{anchor_fset.schema_name}.{anchor_fset.table_name} {alias} '
-    remaining_fsets = [fset for fset in feature_sets if fset != anchor_fset]
-
-    # SELECT clause
-    feature_names = ','.join([f'fset{feature.feature_set_id}.{feature.name}' for feature in features])
-    # Include the pk columns of the anchor feature set
-    pk_cols = ','.join([f'{alias}.{pk}' for pk in anchor_fset.pk_columns])
-    all_feature_columns = feature_names + ',' + pk_cols
-
-    sql = f'SELECT {all_feature_columns} \nFROM {anchor_fset_schema}'
-
-    # JOIN clause
-    for fset in remaining_fsets:
-        # Join Feature Set
-        sql += f'\nLEFT OUTER JOIN {fset.schema_name}.{fset.table_name} fset{fset.feature_set_id} \n\tON '
-        for ind, pkcol in enumerate(fset.pk_columns):
-            if ind > 0: sql += ' AND '  # In case of multiple columns
-            sql += f'fset{fset.feature_set_id}.{pkcol}={alias}.{pkcol}'
-    return sql
-
-
-def _create_temp_training_view(features: List[Feature], feature_sets: List[FeatureSet]) -> TrainingView:
-    """
-    Internal function to create a temporary Training View for training set retrieval using a Feature Set. When
-    a user created
-
-    :param fsets: List[FeatureSet]
-    :param features: List[Feature]
-    :return: Generated Training View
-    """
-    anchor_fset = _get_anchor_feature_set(features, feature_sets)
-    anchor_pk_column_sql = ','.join(anchor_fset.pk_columns)
-    ts_col = 'LAST_UPDATE_TS'
-    schema_table_name = f'{anchor_fset.schema_name}.{anchor_fset.table_name}_history'
-    view_sql = f'SELECT {anchor_pk_column_sql}, ASOF_TS as {ts_col} FROM {schema_table_name}'
-    return TrainingView(pk_columns=anchor_fset.pk_columns, ts_column=ts_col, view_sql=view_sql,
-                        description=None, name=None, label_column=None)
+        if not splice_ctx:
+            raise SpliceMachineException("You either didn't specify a return_type or set it to 'spark', but you have not "
+                                         "registered a PySpliceContext or ExtPySpliceContext. Either register one with the"
+                                         "register_splice_context function or change the return type to one of "
+                                         f"{ReturnType.get_valid() - {'spark'}}")
+        return splice_ctx.df(response['sql'])
 


### PR DESCRIPTION
Support returning training sets as pandas dataframes dataframes (under 50MB) 

## Description
This enables users to use the featurestore without spark and get small datasets as pandas dataframes

## Motivation and Context
More flexibility with the feature store usage, no need for spark on small datasets.

## Dependencies
[ml-workflow](https://github.com/splicemachine/ml-workflow/pull/158)

## How Has This Been Tested?
Against K8s

## Screenshots (if appropriate):

## Changelog Inclusions

<!-- Text Entered in these sections will appear as it is written, MD formatted -->
<!-- Avoid using the # character as the first character on any line, a trim is -->
<!-- performed on each line when checking for markdown section tags -->
- base feature note
  - **BREAKING** note on base feature
  - Basically whatever formatting we have here, just plain-text
	%> command example
- next feature
  - note on next feature
<!-- If there is NO text in a section, no entries will be collected for that section -->

### Additions
Support training sets as JSOn and Pandas (under 50MB)
### Changes

### Fixes

### Deprecated
The `return_sql` parameter is deprecated and will be removed in a future release
### Removed

### Breaking Changes
