### PR TITLE
DBAAS-5518: live model status route

### DIFF
--- a/splicemachine/mlflow_support/mlflow_support.py
+++ b/splicemachine/mlflow_support/mlflow_support.py
@@ -1055,11 +1055,13 @@ def _get_deployed_models() -> PandasDF:
     :return: Pandas df
     """
 
-    return mlflow._splice_context.df(
-        """
-        SELECT * FROM MLMANAGER.LIVE_MODEL_STATUS
-        """
-    ).toPandas()
+    request = requests.get(
+        get_jobs_uri(mlflow.get_tracking_uri() or get_pod_uri('mlflow', 5003, _testing=_TESTING)) + "/api/rest/deployments",
+        auth=mlflow._basic_auth
+    )
+    if not request.ok:
+        raise SpliceMachineException(request.text)
+    return PandasDF(dict(request.json()))
 
 
 def apply_patches():


### PR DESCRIPTION
Server side route to get live model status

## Description
Helpful route to see which models are deployed and the status of their deployment (does the table still exist? Does the trigger?)

## Motivation and Context
Helpful for users to know what models are deployed
Adds authentication to the route since it is server side now
Removes Spark / NSDS dependency

## Dependencies
[ml-workflow](https://github.com/splicemachine/ml-workflow/pull/169)

## How Has This Been Tested?
![image](https://user-images.githubusercontent.com/22605641/118181587-ec772700-b405-11eb-9f88-e017cbf8c007.png)

## Screenshots (if appropriate):

## Changelog Inclusions


### Additions
server side get_deployed_models function 

