### PR TITLE
fix for server change to return single dictionary if result contains …

### DIFF
--- a/splicemachine/features/feature_store.py
+++ b/splicemachine/features/feature_store.py
@@ -667,9 +667,9 @@ class FeatureStore:
         :return: None
         """
         r = make_request(self._FS_URL, Endpoints.FEATURE_SET_DETAILS, RequestType.GET, self._auth)
-        
+
         print('Available feature sets')
-        for desc in r:
+        for desc in r if type(r) == list else [r]:
             features = [Feature(**feature) for feature in desc.pop('features')]
             fset = FeatureSet(**desc)
             print('-' * 23)
@@ -713,7 +713,7 @@ class FeatureStore:
         r = make_request(self._FS_URL, Endpoints.TRAINING_VIEW_DETAILS, RequestType.GET, self._auth)
 
         print('Available training views')
-        for desc in r:
+        for desc in r if type(r) == list else [r]:
             features = [Feature(**f) for f in desc.pop('features')]
             tcx = TrainingView(**desc)
             print('-' * 23)


### PR DESCRIPTION
fix for server change to return single dictionary if result contains only 1 element

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Dependencies
<!--- If this fix is dependent on code in other repos to be deployed, list that here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Changelog Inclusions

<!-- Text Entered in these sections will appear as it is written, MD formatted -->
<!-- Avoid using the # character as the first character on any line, a trim is -->
<!-- performed on each line when checking for markdown section tags -->
- base feature note
  - **BREAKING** note on base feature
  - Basically whatever formatting we have here, just plain-text
	%> command example
- next feature
  - note on next feature
<!-- If there is NO text in a section, no entries will be collected for that section -->

### Additions

### Changes

### Fixes

### Deprecated

### Removed

### Breaking Changes
