### PR TITLE
DBAAS-5536: Add versioning to all entities in the feature store

### DIFF
--- a/splicemachine/features/feature_store.py
+++ b/splicemachine/features/feature_store.py
@@ -605,6 +605,7 @@ class FeatureStore:
         :param table_name: The table name for this feature set
         :param primary_keys: The primary key column(s) of this feature set
         :param desc: The (optional) description
+        :param version: The version you wish to alter (number or 'latest'). If None, will default to the latest undeployed version
         :return: FeatureSet
         """
         if isinstance(version, str) and version != 'latest':
@@ -753,11 +754,10 @@ class FeatureStore:
         :param primary_keys: (List[str]) The list of columns from the training SQL that identify the training row
         :param ts_col: The timestamp column of the training SQL that identifies the inference timestamp
         :param label_col: (Optional[str]) The optional label column from the training SQL.
-        :param replace: (Optional[bool]) Whether to replace an existing training view
         :param join_keys: (List[str]) A list of join keys in the sql that are used to get the desired features in
             get_training_set
         :param desc: (Optional[str]) An optional description of the training set
-        :param verbose: Whether or not to print the SQL before execution (default False)
+        :param version: The version you wish to alter (number or 'latest'). If None, will default to the latest version
         :return:
         """
         assert name != "None", "Name of training view cannot be None!"

--- a/splicemachine/features/feature_store.py
+++ b/splicemachine/features/feature_store.py
@@ -598,7 +598,7 @@ class FeatureStore:
     def alter_feature_set(self, schema_name: str, table_name: str, primary_keys: Optional[Dict[str, str]] = None,
                            desc: Optional[str] = None, version: Optional[Union[str, int]] = None) -> FeatureSet:
         """
-        Alters the latest version of a feature set, if that version is not yet deployed. Use this method when you want to make changes to
+        Alters the specified (or default latest) version of a feature set, if that version is not yet deployed. Use this method when you want to make changes to
         an undeployed version of a feature set, or when you want to change version-independant metadata, such as description.
 
         :param schema_name: The schema under which to create the feature set table

--- a/splicemachine/features/training_set.py
+++ b/splicemachine/features/training_set.py
@@ -43,6 +43,7 @@ class TrainingSet:
             print("There is an active mlflow run, your training set will be logged to that run.")
             try:
                 mlflow_ctx.lp("splice.feature_store.training_view_id",self.training_view.view_id)
+                mlflow_ctx.lp("splice.feature_store.training_view_version",self.training_view.view_version)
                 mlflow_ctx.lp("splice.feature_store.training_set_start_time",str(self.start_time))
                 mlflow_ctx.lp("splice.feature_store.training_set_end_time",str(self.end_time))
                 mlflow_ctx.lp("splice.feature_store.training_set_create_time",str(self.create_time))

--- a/splicemachine/features/training_view.py
+++ b/splicemachine/features/training_view.py
@@ -1,15 +1,16 @@
 from typing import List
 
 class TrainingView:
-    def __init__(self, *, pk_columns: List[str], ts_column, label_column, view_sql, name, description,
-                 view_id = None, **kwargs):
+    def __init__(self, *, pk_columns: List[str], ts_column, label_column, sql_text, name, description,
+                 view_id = None, view_version = None, **kwargs):
         self.pk_columns = pk_columns
         self.ts_column = ts_column
         self.label_column = label_column
-        self.view_sql = view_sql
+        self.sql_text = sql_text
         self.name = name
         self.description = description
         self.view_id = view_id
+        self.view_version = view_version
         args = {k.lower(): kwargs[k] for k in kwargs} # Make all keys lowercase
         args = {k: args[k].split(',') if 'columns' in k and isinstance(args[k], str) else args[k] for k in args} # Make value a list for specific pkcolumns and contextcolumns because Splice doesn't support Arrays
         self.__dict__.update(args)
@@ -19,7 +20,7 @@ class TrainingView:
                f'PKColumns={self.pk_columns}, ' \
                f'TSColumn={self.ts_column}, ' \
                f'LabelColumn={self.label_column}, \n' \
-               f'ViewSQL={self.view_sql}, \n' \
+               f'ViewSQL={self.sql_text}, \n' \
                f'ViewID={self.view_id}'
 
     def __str__(self):

--- a/splicemachine/features/utils/http_utils.py
+++ b/splicemachine/features/utils/http_utils.py
@@ -11,18 +11,20 @@ class RequestType:
     GET: str = "GET"
     POST: str = "POST"
     PUT: str = "PUT"
+    PATCH: str = "PATCH"
     DELETE: str = "DELETE"
 
     method_map = { 
         GET: requests.get,
         POST: requests.post,
         PUT: requests.put,
+        PATCH: requests.patch,
         DELETE: requests.delete
     }
 
     @staticmethod
     def get_valid() -> Tuple[str]:
-        return (RequestType.GET, RequestType.POST, RequestType.PUT, RequestType.DELETE)
+        return (RequestType.GET, RequestType.POST, RequestType.PUT, RequestType.PATCH, RequestType.DELETE)
 
 class Endpoints:
     """


### PR DESCRIPTION
## Description
Implementing support for versioning

## Motivation and Context
When we implement  transformations and pipelines, changes to either of those will result in new features and feature sets, so we must have a way to version everything.

## Dependencies
[ml-workflow](https://github.com/splicemachine/ml-workflow/pull/188)

## How Has This Been Tested?
Tested locally and on cluster db

## Screenshots (if appropriate):

## Changelog Inclusions

### Additions
- update/alter feature set
- update/alter training view
- 'version' parameter to many functions that need to support versioning

### Changes

### Fixes

### Deprecated

### Removed

### Breaking Changes
