### PR TITLE
DBAAS-5538: Add Pipes as a first class feature store object

### DIFF
--- a/splicemachine/features/constants.py
+++ b/splicemachine/features/constants.py
@@ -37,6 +37,25 @@ class PipeType:
             PipeType.source, PipeType.batch, PipeType.online, PipeType.realtime
         )
 
+class PipeLanguage:
+    """
+    Class containing names for
+    valid pipe languages
+    """
+    pyspark: str = "pyspark"
+    python: str = "python"
+    sql: str = "sql"
+    
+    @staticmethod
+    def get_valid() -> tuple:
+        """
+        Return a tuple of the valid pipe languages
+        :return: (tuple) valid languages
+        """
+        return (
+            PipeLanguage.pyspark, PipeLanguage.python, PipeLanguage.sql
+        )
+
 
 class SQL:
     FEATURE_STORE_SCHEMA = 'FeatureStore'

--- a/splicemachine/features/constants.py
+++ b/splicemachine/features/constants.py
@@ -17,6 +17,27 @@ class FeatureType:
             FeatureType.categorical, FeatureType.ordinal, FeatureType.continuous,
         )
 
+class PipeType:
+    """
+    Class containing names for
+    valid pipe types
+    """
+    source: str = "S"
+    batch: str = "B"
+    online: str = "O"
+    realtime: str = "R"
+    
+    @staticmethod
+    def get_valid() -> tuple:
+        """
+        Return a tuple of the valid pipe types
+        :return: (tuple) valid types
+        """
+        return (
+            PipeType.source, PipeType.batch, PipeType.online, PipeType.realtime
+        )
+
+
 class SQL:
     FEATURE_STORE_SCHEMA = 'FeatureStore'
 

--- a/splicemachine/features/feature_store.py
+++ b/splicemachine/features/feature_store.py
@@ -1058,15 +1058,26 @@ class FeatureStore:
         r = make_request(self._FS_URL, Endpoints.PIPES, RequestType.GET, self._auth, { "name": names })
         return [Pipe(**p, splice_ctx=self.splice_ctx) for p in r]
 
-    def get_pipe(self, name: str, version: Optional[Union[str, int]] = None) -> List[Pipe]:
+    def get_pipe(self, name: str, version: Optional[Union[str, int]] = 'latest') -> Pipe:
+        """
+        Returns a pipe version
+
+        :param name: The pipe name
+        :param version: The version to return (either an int or 'latest'). Default is 'latest'
+        :return: List[Pipe] The list of Pipe objects
+        """
+        assert version, "version cannot be none!"
+        r = make_request(self._FS_URL, f'{Endpoints.PIPES}/{name}', RequestType.GET, self._auth, { "version": version })
+        return Pipe(**r[0], splice_ctx=self.splice_ctx)
+
+    def get_pipe_versions(self, name: str) -> List[Pipe]:
         """
         Returns a pipe version or list of pipe versions for a provided pipe name
 
         :param name: The pipe name
-        :param version: The version to return (either an int or 'latest'). If None, all versions are returned
         :return: List[Pipe] The list of Pipe objects
         """
-        r = make_request(self._FS_URL, f'{Endpoints.PIPES}/{name}', RequestType.GET, self._auth, { "version": version })
+        r = make_request(self._FS_URL, f'{Endpoints.PIPES}/{name}', RequestType.GET, self._auth)
         return [Pipe(**p, splice_ctx=self.splice_ctx) for p in r]
 
     def create_pipe(self, name: str, ptype: str, lang: str, func: Callable, description: Optional[str] = None) -> Pipe:

--- a/splicemachine/features/feature_store.py
+++ b/splicemachine/features/feature_store.py
@@ -1070,8 +1070,7 @@ class FeatureStore:
         r = make_request(self._FS_URL, f'{Endpoints.PIPES}/{name}', RequestType.GET, self._auth, { "version": version })
         return [Pipe(**p, splice_ctx=self.splice_ctx) for p in r]
 
-    def create_pipe(self, name: str, ptype: str, lang: str, func: Callable,
-                            description: Optional[str] = None) -> Pipe:
+    def create_pipe(self, name: str, ptype: str, lang: str, func: Callable, description: Optional[str] = None) -> Pipe:
         """
         Creates and returns a new pipe
 
@@ -1097,8 +1096,8 @@ class FeatureStore:
                                                         f"languages include {PipeLanguage.get_valid()}. Use the PipeLanguage" \
                                                         f" class provided by splicemachine.features"
 
-        f = base64.encodebytes(cloudpickle.dumps(function)).decode('ascii').strip()
-        p_dict = { "name": name, "description": description, "ptype": ptype, "lang": lang, "func": f, "code": getsource(function) }
+        f = base64.encodebytes(cloudpickle.dumps(func)).decode('ascii').strip()
+        p_dict = { "name": name, "description": description, "ptype": ptype, "lang": lang, "func": f, "code": getsource(func) }
 
         print(f'Registering Pipe {name} in the Feature Store')
         r = make_request(self._FS_URL, Endpoints.PIPES, RequestType.POST, self._auth, body=p_dict)

--- a/splicemachine/features/feature_store.py
+++ b/splicemachine/features/feature_store.py
@@ -8,7 +8,6 @@ import pandas as pd
 from pandas import DataFrame as PandasDF
 import cloudpickle
 import base64
-from inspect import getsource
 
 from pyspark.sql.dataframe import DataFrame as SparkDF
 from pyspark.ml import Pipeline
@@ -1097,7 +1096,7 @@ class FeatureStore:
                                                         f" class provided by splicemachine.features"
 
         f = base64.encodebytes(cloudpickle.dumps(func)).decode('ascii').strip()
-        p_dict = { "name": name, "description": description, "ptype": ptype, "lang": lang, "func": f, "code": getsource(func) }
+        p_dict = { "name": name, "description": description, "ptype": ptype, "lang": lang, "func": f }
 
         print(f'Registering Pipe {name} in the Feature Store')
         r = make_request(self._FS_URL, Endpoints.PIPES, RequestType.POST, self._auth, body=p_dict)
@@ -1116,7 +1115,7 @@ class FeatureStore:
         assert name != "None", "Name of pipe cannot be None!"
 
         f = base64.encodebytes(cloudpickle.dumps(func)).decode('ascii').strip()
-        p_dict = { "description": description, "func": f, "code": getsource(func) }
+        p_dict = { "description": description, "func": f }
 
         print(f'Updating Pipe {name} in the Feature Store')
         r = make_request(self._FS_URL, f'{Endpoints.PIPES}/{name}', RequestType.PUT, self._auth, body=p_dict)
@@ -1135,9 +1134,10 @@ class FeatureStore:
         :return:
         """
         assert name != "None", "Name of pipe cannot be None!"
+        assert func or description, "Please enter either a function or description"
 
         f = base64.encodebytes(cloudpickle.dumps(func)).decode('ascii').strip() if func else None
-        p_dict = { "description": description, "func": f, "code": getsource(func) if func else None }
+        p_dict = { "description": description, "func": f }
         params = { "version" : version }
 
         print(f'Altering Pipe {name} in the Feature Store')

--- a/splicemachine/features/pipe.py
+++ b/splicemachine/features/pipe.py
@@ -3,12 +3,12 @@ import cloudpickle
 import base64
 
 class Pipe:
-    def __init__(self, *, name, description, type, language, function, code, pipe_id=None, pipe_version=None, splice_ctx=None, **kwargs):
+    def __init__(self, *, name, description, ptype, lang, func, code, pipe_id=None, pipe_version=None, splice_ctx=None, **kwargs):
         self.name = name.upper()
         self.description = description
-        self.type = type
-        self.language = language
-        self.function = base64.decodebytes(function.encode('ascii'))
+        self.ptype = ptype
+        self.lang = lang
+        self.func = base64.decodebytes(func.encode('ascii'))
         self.code = code
         self.pipe_id = pipe_id
         self.pipe_version = pipe_version
@@ -16,8 +16,29 @@ class Pipe:
         args = {k.lower(): kwargs[k] for k in kwargs}
         self.__dict__.update(args)
 
+    @property
+    def type(self):
+        return self.ptype
+    @type.setter
+    def x(self, value):
+        self.ptype = value
+
+    @property
+    def language(self):
+        return self.lang
+    @language.setter
+    def x(self, value):
+        self.lang = value
+
+    @property
+    def function(self):
+        return self.func
+    @function.setter
+    def x(self, value):
+        self.func = value
+
     def apply(self, *args, **kwargs):   
-        func = cloudpickle.loads(self.function)
+        func = cloudpickle.loads(self.func)
         if self.language == 'pyspark':
             func.__globals__['splice'] = self.splice_ctx 
         r = func(*args, **kwargs)

--- a/splicemachine/features/pipe.py
+++ b/splicemachine/features/pipe.py
@@ -1,0 +1,31 @@
+from splicemachine import SpliceMachineException
+import cloudpickle
+import base64
+
+class Pipe:
+    def __init__(self, *, name, description, type, language, function, code, pipe_id=None, pipe_version=None, splice_ctx=None, **kwargs):
+        self.name = name.upper()
+        self.description = description
+        self.type = type
+        self.language = language
+        self.function = base64.decodebytes(function.encode('ascii'))
+        self.code = code
+        self.pipe_id = pipe_id
+        self.pipe_version = pipe_version
+        self.splice_ctx = splice_ctx
+        args = {k.lower(): kwargs[k] for k in kwargs}
+        self.__dict__.update(args)
+
+    def apply(self, *args, **kwargs):   
+        func = cloudpickle.loads(self.function)
+        if self.language == 'pyspark':
+            func.__globals__['splice'] = self.splice_ctx 
+        r = func(*args, **kwargs)
+        if self.language == 'sql':
+            if not self.splice_ctx:
+                raise SpliceMachineException(f'Cannot execute SQL functions without a splice context')
+            return self.splice_ctx.df(r)
+        else: # 'python'
+            return r
+
+

--- a/splicemachine/features/utils/http_utils.py
+++ b/splicemachine/features/utils/http_utils.py
@@ -56,6 +56,7 @@ class Endpoints:
     BACKFILL_SQL: str = 'backfill-sql'
     BACKFILL_INTERVALS: str = 'backfill-intervals'
     PIPELINE_SQL: str = 'pipeline-sql'
+    PIPES: str = 'pipes'
 
 def make_request(url: str, endpoint: str, method: str, auth: str,
                  params: Optional[Dict[str, Any]] = None,


### PR DESCRIPTION
## Description
New methods for getting, creating, updating, altering, and deleting pipes

## Motivation and Context
We need to support Pipes as a first class object in the feature store before being able to create pipelines and schedules in airflow. 
Fixes [DBAAS-5538](https://splicemachine.atlassian.net/browse/DBAAS-5538)

## Dependencies
[ml-workflow](https://github.com/splicemachine/ml-workflow/pull/193)

## How Has This Been Tested?
Tested against standalone db

## Changelog Inclusions

### Additions
- New Pipe object
- New functions for getting, creating, updating, altering and deleting pipes

### Changes

### Fixes
- Minor training view bugs

### Deprecated

### Removed

### Breaking Changes
