### PR TITLE
DBAAS-5578: Add Pipelines as a first class feature store object

### DIFF
--- a/splicemachine/features/__init__.py
+++ b/splicemachine/features/__init__.py
@@ -1,4 +1,4 @@
 from .feature import Feature
 from .feature_set import FeatureSet
 from .feature_store import FeatureStore
-from .constants import FeatureType
+from .constants import FeatureType, PipeType, PipeLanguage

--- a/splicemachine/features/feature_store.py
+++ b/splicemachine/features/feature_store.py
@@ -27,6 +27,7 @@ from .utils.training_utils import ReturnType, _format_training_set_output
 from .pipelines import FeatureAggregation, AggWindow
 from .utils.http_utils import RequestType, make_request, _get_feature_store_url, Endpoints, _get_credentials, _get_token
 from .pipe import Pipe
+from .pipeline import Pipeline
 
 from .constants import PipeLanguage, SQL, FeatureType, PipeType
 from .training_view import TrainingView
@@ -793,7 +794,7 @@ class FeatureStore:
 
     def deploy_feature_set(self, schema_name: str, table_name: str, version: Union[str, int] = 'latest', migrate: bool = False):
         """
-        Deploys a feature set to the database. This persists the feature stores existence.
+        Deploys a feature set to the database. This persists the feature sets existence.
         As of now, once deployed you cannot delete the feature set or add/delete features.
         The feature set must have already been created with :py:meth:`~features.FeatureStore.create_feature_set`
 
@@ -1118,7 +1119,7 @@ class FeatureStore:
         Creates and returns a new version of a pipe. Use this function when you want to
         make changes to a pipe without affecting its dependencies
 
-        :param name: The training set name.
+        :param name: The pipe name.
         :param func: The actual python function or sql query used in the transformation
         :param description: (Optional[str]) An optional description of the pipe
         :return:
@@ -1138,7 +1139,7 @@ class FeatureStore:
         Alters an existing version of a pipe. Use this method when you want to make changes to a version of a pipe
         that has no dependencies, or when you want to change version-independent metadata, such as description.
 
-        :param name: The training set name.
+        :param name: The pipe name.
         :param func: The actual python function or sql query used in the transformation
         :param description: (Optional[str]) An optional description of the pipe
         :param version: The version to alter (either an int or 'latest'). Default 'latest'
@@ -1146,6 +1147,8 @@ class FeatureStore:
         """
         assert name != "None", "Name of pipe cannot be None!"
         assert func or description, "Please enter either a function or description"
+        if isinstance(version, str) and version != 'latest':
+            raise SpliceMachineException("Version parameter must be a number or 'latest'")
 
         f = base64.encodebytes(cloudpickle.dumps(func)).decode('ascii').strip() if func else None
         p_dict = { "description": description, "func": f }
@@ -1159,16 +1162,180 @@ class FeatureStore:
         """
         Removes an existing version of a pipe. If no versions remain, deletes pipe metadata.
 
-        :param name: The training set name.
+        :param name: The pipe name.
         :param version: The version to remove (either an int or 'latest'). If None, removes all versions
         :return:
         """
         assert name != "None", "Name of pipe cannot be None!"
+        if isinstance(version, str) and version != 'latest':
+            raise SpliceMachineException("Version parameter must be a number or 'latest'")
 
         p_dict = { "version": version }
 
         print(f'Removing Pipe {name} from the Feature Store')
         make_request(self._FS_URL, f'{Endpoints.PIPES}/{name}', RequestType.DELETE, self._auth, params=p_dict)
+
+    def get_pipelines(self, names: Optional[List[str]] = None) -> List[Pipeline]:
+        """
+        Returns a list of pipelines whose names are provided
+
+        :param names: The list of pipeline names
+        :return: List[Piplinee] The list of Pipeline objects
+        """
+        r = make_request(self._FS_URL, Endpoints.PIPELINES, RequestType.GET, self._auth, { "name": names })
+        pipelines = []
+        for pl in r:
+            pl['pipes'] = [Pipe(**p, splice_ctx=self.splice_ctx) for p in pl['pipes']]
+            pipelines.append(Pipeline(**pl))
+        return pipelines
+
+    def get_pipeline(self, name: str, version: Optional[Union[str, int]] = 'latest') -> Pipeline:
+        """
+        Returns a pipeline version
+
+        :param name: The pipeline name
+        :param version: The version to return (either an int or 'latest'). Default is 'latest'
+        :return: List[Pipeline] The list of Pipeline objects
+        """
+        assert version, "version cannot be none!"
+        if isinstance(version, str) and version != 'latest':
+            raise SpliceMachineException("Version parameter must be a number or 'latest'")
+        
+        r = make_request(self._FS_URL, f'{Endpoints.PIPELINES}/{name}', RequestType.GET, self._auth, { "version": version })
+        pl = r[0]
+        pl['pipes'] = [Pipe(**p, splice_ctx=self.splice_ctx) for p in pl['pipes']]
+        return Pipeline(**pl)
+
+    def get_pipeline_versions(self, name: str) -> List[Pipeline]:
+        """
+        Returns a pipeline version or list of pipeline versions for a provided pipeline name
+
+        :param name: The pipeline name
+        :return: List[Pipe] The list of Pipeline objects
+        """
+        r = make_request(self._FS_URL, f'{Endpoints.PIPELINES}/{name}', RequestType.GET, self._auth)
+        pipelines = []
+        for pl in r:
+            pl['pipes'] = [Pipe(**p, splice_ctx=self.splice_ctx) for p in pl['pipes']]
+            pipelines.append(Pipeline(**pl))
+        return pipelines
+
+    def create_pipeline(self, name: str, pipeline_start_ts: datetime, pipeline_interval: str, pipes: List[Union[str, Pipe]], description: Optional[str] = None) -> Pipeline:
+        """
+        Creates and returns a new pipeline
+
+        :param name: The pipeline name. This must be unique to other pipelines
+        :param pipeline_start_ts: The start time of the pipe when deployed. This can be in the past, if a backfill is desired, or in the future
+        :param pipeline_interval: str The interval at which to run the pipeline. Either a cron expression or an Airflow cron preset
+        :param pipes: An (ordered) list of the pipes (or pipe names) that make up this pipeline
+        :param description: (Optional[str]) An optional description of the pipeline
+        :return:
+        """
+        pipes = [p if isinstance(p, str) else p._to_json() for p in pipes]
+        p_dict = { "name": name, "description": description, "pipeline_start_ts": str(pipeline_start_ts), "pipeline_interval": pipeline_interval, "pipes": pipes }
+
+        print(f'Registering Pipeline {name} in the Feature Store')
+        r = make_request(self._FS_URL, Endpoints.PIPELINES, RequestType.POST, self._auth, body=p_dict)
+        r['pipes'] = [Pipe(**p, splice_ctx=self.splice_ctx) for p in r['pipes']]
+        return Pipeline(**r)
+
+    def update_pipeline(self, name: str, pipeline_start_ts: datetime, pipeline_interval: str, pipes: List[Union[str, Pipe]], description: Optional[str] = None) -> Pipeline:
+        """
+        Creates and returns a new version of a pipeline. Use this function when you want to
+        make changes to a pipeline without affecting its dependencies
+
+        :param name: The pipeline name. This must be unique to other pipelines
+        :param pipeline_start_ts: The start time of the pipe when deployed. This can be in the past, if a backfill is desired, or in the future
+        :param pipeline_interval: str The interval at which to run the pipeline. Either a cron expression or an Airflow cron preset
+        :param pipes: An (ordered) list of the pipes (or pipe names) that make up this pipeline
+        :param description: (Optional[str]) An optional description of the pipeline
+        :return:
+        """
+        assert name != "None", "Name of pipeline cannot be None!"
+
+        pipes = [p if isinstance(p, str) else p._to_json() for p in pipes]
+        p_dict = { "description": description, "pipeline_start_ts": str(pipeline_start_ts), "pipeline_interval": pipeline_interval, "pipes": pipes }
+
+        print(f'Updating Pipeline {name} in the Feature Store')
+        r = make_request(self._FS_URL, f'{Endpoints.PIPELINES}/{name}', RequestType.PUT, self._auth, body=p_dict)
+        r['pipes'] = [Pipe(**p, splice_ctx=self.splice_ctx) for p in r['pipes']]
+        return Pipeline(**r)
+
+    def alter_pipeline(self, name: str, pipeline_start_ts: Optional[datetime] = None, pipeline_interval: Optional[str] = None, pipes: Optional[List[Union[str, Pipe]]] = None, 
+                    description: Optional[str] = None, version: Union[int, str] = 'latest') -> Pipe:
+        """
+        Alters an existing version of a pipeline. Use this method when you want to make changes to a version of a pipeline
+        that has no dependencies, or when you want to change version-independent metadata, such as description.
+
+        :param name: The pipeline name. This must be unique to other pipelines
+        :param pipeline_start_ts: The start time of the pipe when deployed. This can be in the past, if a backfill is desired, or in the future
+        :param pipeline_interval: str The interval at which to run the pipeline. Either a cron expression or an Airflow cron preset
+        :param pipes: An (ordered) list of the pipes (or pipe names) that make up this pipeline
+        :param description: (Optional[str]) An optional description of the pipeline
+        :param version: The version to alter (either an int or 'latest'). Default 'latest'
+        :return:
+        """
+        assert name != "None", "Name of pipeline cannot be None!"
+        assert pipeline_start_ts or pipeline_start_ts or pipes or description, "At least one attribute must be entered to alter"
+        if isinstance(version, str) and version != 'latest':
+            raise SpliceMachineException("Version parameter must be a number or 'latest'")
+
+        pipes = [p if isinstance(p, str) else p._to_json() for p in pipes] if pipes else None
+        p_dict = { "description": description, "pipeline_start_ts": str(pipeline_start_ts) if pipeline_start_ts else None, "pipeline_interval": pipeline_interval, "pipes": pipes }
+        params = { "version" : version }
+
+        print(f'Altering Pipeline {name} in the Feature Store')
+        r = make_request(self._FS_URL, f'{Endpoints.PIPELINES}/{name}', RequestType.PATCH, self._auth, params=params, body=p_dict)
+        r['pipes'] = [Pipe(**p, splice_ctx=self.splice_ctx) for p in r['pipes']]
+        return Pipeline(**r)
+
+    def remove_pipeline(self, name: str, version: Union[int, str] = None) -> None:
+        """
+        Removes an existing version of a pipeline. If no versions remain, deletes pipeline metadata.
+
+        :param name: The pipeline name.
+        :param version: The version to remove (either an int or 'latest'). If None, removes all versions
+        :return:
+        """
+        assert name != "None", "Name of pipeline cannot be None!"
+        if isinstance(version, str) and version != 'latest':
+            raise SpliceMachineException("Version parameter must be a number or 'latest'")
+
+        p_dict = { "version": version }
+
+        print(f'Removing Pipe {name} from the Feature Store')
+        make_request(self._FS_URL, f'{Endpoints.PIPELINES}/{name}', RequestType.DELETE, self._auth, params=p_dict)
+
+    def deploy_pipeline(self, name: str, schema_name: str, table_name: str, version: Union[str, int] = 'latest'):
+        """
+        Deploys a pipeline to a specified feature set. This schedules the pipeline as an Airflow DAG, with each pipe as its own task
+
+        :param name: The name of the pipeline
+        :param schema_name: The schema of the feature set
+        :param table_name: The table of the feature set
+        :param version: The version of the pipeline to deploy
+        """
+        if isinstance(version, str) and version != 'latest':
+            raise SpliceMachineException("Version parameter must be a number or 'latest'")
+        # database stores object names in upper case
+        schema_name = schema_name.upper()
+        table_name = table_name.upper()
+        print(f'Deploying Pipeline {name}...',end=' ')
+        make_request(self._FS_URL, Endpoints.DEPLOY_PIPELINE, RequestType.POST, self._auth, { "name": name, "schema": schema_name, "table": table_name, "version": version })
+        print('Done.')
+
+    def undeploy_pipeline(self, name: str, version: Union[str, int] = 'latest'):
+        """
+        Undeploys a pipeline to a specified feature set. This unschedules the associated Airflow DAG
+
+        :param name: The name of the pipeline
+        :param version: The version of the pipeline to undeploy
+        """
+        if isinstance(version, str) and version != 'latest':
+            raise SpliceMachineException("Version parameter must be a number or 'latest'")
+        print(f'Undeploying Pipeline {name}...',end=' ')
+        make_request(self._FS_URL, Endpoints.UNDEPLOY_PIPELINE, RequestType.POST, self._auth, { "name": name, "version": version })
+        print('Done.')
 
     def create_source(self, name: str, sql: str, event_ts_column: datetime,
                       update_ts_column: datetime, primary_keys: List[str]):

--- a/splicemachine/features/feature_store.py
+++ b/splicemachine/features/feature_store.py
@@ -1336,8 +1336,10 @@ class FeatureStore:
         schema_name = schema_name.upper()
         table_name = table_name.upper()
         print(f'Deploying Pipeline {name}...',end=' ')
-        make_request(self._FS_URL, Endpoints.DEPLOY_PIPELINE, RequestType.POST, self._auth, { "name": name, "schema": schema_name, "table": table_name, "version": version })
+        r = make_request(self._FS_URL, Endpoints.DEPLOY_PIPELINE, RequestType.POST, self._auth, { "name": name, "schema": schema_name, "table": table_name, "version": version })
         print('Done.')
+        r['pipes'] = [Pipe(**p, splice_ctx=self.splice_ctx) for p in r['pipes']]
+        return Pipeline(**r)
 
     def undeploy_pipeline(self, name: str, version: Union[str, int] = 'latest'):
         """
@@ -1349,8 +1351,10 @@ class FeatureStore:
         if isinstance(version, str) and version != 'latest':
             raise SpliceMachineException("Version parameter must be a number or 'latest'")
         print(f'Undeploying Pipeline {name}...',end=' ')
-        make_request(self._FS_URL, Endpoints.UNDEPLOY_PIPELINE, RequestType.POST, self._auth, { "name": name, "version": version })
+        r = make_request(self._FS_URL, Endpoints.UNDEPLOY_PIPELINE, RequestType.POST, self._auth, { "name": name, "version": version })
         print('Done.')
+        r['pipes'] = [Pipe(**p, splice_ctx=self.splice_ctx) for p in r['pipes']]
+        return Pipeline(**r)
 
     def create_source(self, name: str, sql: str, event_ts_column: datetime,
                       update_ts_column: datetime, primary_keys: List[str]):

--- a/splicemachine/features/pipe.py
+++ b/splicemachine/features/pipe.py
@@ -1,48 +1,87 @@
+from splicemachine.features.constants import PipeLanguage, PipeType
 from splicemachine import SpliceMachineException
 import cloudpickle
 import base64
 
 class Pipe:
-    def __init__(self, *, name, description, ptype, lang, func, code, pipe_id=None, pipe_version=None, splice_ctx=None, **kwargs):
+    def __init__(self, *, name, description, ptype, lang, func, code, pipe_id=None, pipe_version=None, splice_ctx=None, args=None, kwargs=None, **obj_kwargs):
         self.name = name.upper()
         self.description = description
         self.ptype = ptype
         self.lang = lang
-        self.func = base64.decodebytes(func.encode('ascii'))
+        self.func = byteify_string(func)
         self.code = code
         self.pipe_id = pipe_id
         self.pipe_version = pipe_version
         self.splice_ctx = splice_ctx
-        args = {k.lower(): kwargs[k] for k in kwargs}
+        self._args = byteify_string(args)
+        self._kwargs = byteify_string(kwargs)
+        args = {k.lower(): obj_kwargs[k] for k in obj_kwargs}
         self.__dict__.update(args)
 
     @property
     def type(self):
         return self.ptype
     @type.setter
-    def x(self, value):
+    def type(self, value):
         self.ptype = value
 
     @property
     def language(self):
         return self.lang
     @language.setter
-    def x(self, value):
+    def language(self, value):
         self.lang = value
 
     @property
     def function(self):
         return self.func
     @function.setter
-    def x(self, value):
+    def function(self, value):
         self.func = value
 
-    def apply(self, *args, **kwargs):   
+    @property
+    def args(self):
+        return cloudpickle.loads(self._args) if self._args else tuple()
+    @args.setter
+    def args(self, value):
+        self._args = cloudpickle.dumps(value)
+
+    @property
+    def kwargs(self):
+        return cloudpickle.loads(self._kwargs) if self._kwargs else {}
+    @kwargs.setter
+    def kwargs(self, value):
+        self._kwargs = cloudpickle.dumps(value)
+
+    def set_parameters(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+    def set_splice_ctx(self, splice_ctx):
+        self.splice_ctx = splice_ctx
+
+    def apply(self, *args, **kwargs):
+        a = []
+        req = +(self.type != PipeType.source)
+        if req:
+            a.append(args[0])
+        if args[req:]:
+            a[req:] = args[req:]
+        elif self.args:
+            a[req:] = self.args
+        a = tuple(a)
+
+        kw = {}
+        kw.update(self.kwargs or {})
+        kw.update(kwargs)
+
         func = cloudpickle.loads(self.func)
-        if self.language == 'pyspark':
-            func.__globals__['splice'] = self.splice_ctx 
-        r = func(*args, **kwargs)
-        if self.language == 'sql':
+        if self.language == PipeLanguage.pyspark:
+            func.__globals__['splice'] = self.splice_ctx
+            func.__globals__['spark'] = self.splice_ctx.spark_session
+        r = func(*a, **kw)
+        if self.language == PipeLanguage.sql:
             if not self.splice_ctx:
                 raise SpliceMachineException(f'Cannot execute SQL functions without a splice context')
             return self.splice_ctx.df(r)
@@ -55,9 +94,26 @@ class Pipe:
             'description': self.description,
             'ptype': self.ptype,
             'lang': self.lang,
-            'func': base64.encodebytes(self.func).decode('ascii').strip(),
+            'func': stringify_bytes(self.func),
             'code': self.code,
             'pipe_id': self.pipe_id,
-            'pipe_version': self.pipe_version
+            'pipe_version': self.pipe_version,
+            'args': stringify_bytes(self._args),
+            'kwargs': stringify_bytes(self._kwargs)
         }
 
+    def _pandas_to_spark(self, df):
+        return self.splice_ctx.pandasToSpark(df)
+
+    def _df_to_sql(self, df):
+        return self.splice_ctx.createDataFrameSql(df)
+
+def stringify_bytes(b: bytes) -> str:
+    if b is None:
+        return None
+    return base64.encodebytes(b).decode('ascii').strip()
+
+def byteify_string(s: str) -> bytes:
+    if s is None:
+        return None
+    return base64.decodebytes(s.strip().encode('ascii'))

--- a/splicemachine/features/pipe.py
+++ b/splicemachine/features/pipe.py
@@ -49,4 +49,15 @@ class Pipe:
         else: # 'python'
             return r
 
+    def _to_json(self):
+        return {
+            'name': self.name,
+            'description': self.description,
+            'ptype': self.ptype,
+            'lang': self.lang,
+            'func': base64.encodebytes(self.func).decode('ascii').strip(),
+            'code': self.code,
+            'pipe_id': self.pipe_id,
+            'pipe_version': self.pipe_version
+        }
 

--- a/splicemachine/features/pipeline.py
+++ b/splicemachine/features/pipeline.py
@@ -1,0 +1,20 @@
+class Pipeline:
+    def __init__(self, *, name, description, pipeline_start_ts, pipeline_interval, pipeline_id=None, pipeline_version=None, pipes=None, feature_set_id=None, 
+                    feature_set_version=None, pipeline_url=None, **kwargs):
+        self.name = name.upper()
+        self.description = description
+        self.pipeline_start_ts = pipeline_start_ts
+        self.pipeline_interval = pipeline_interval
+        self.pipeline_id = pipeline_id
+        self.pipeline_version = pipeline_version
+        self.pipes = pipes
+        self.feature_set_id = feature_set_id
+        self.feature_set_version = feature_set_version
+        self.pipeline_url = pipeline_url
+        args = {k.lower(): kwargs[k] for k in kwargs}
+        self.__dict__.update(args)
+
+    def run_pipeline(self, df):
+        for pipe in self.pipes:
+            df = pipe.apply(df)
+        return df

--- a/splicemachine/features/pipeline.py
+++ b/splicemachine/features/pipeline.py
@@ -1,9 +1,11 @@
+from splicemachine.features.constants import PipeLanguage
+
 class Pipeline:
-    def __init__(self, *, name, description, pipeline_start_ts, pipeline_interval, pipeline_id=None, pipeline_version=None, pipes=None, feature_set_id=None, 
+    def __init__(self, *, name, description, pipeline_start_date, pipeline_interval, pipeline_id=None, pipeline_version=None, pipes=None, feature_set_id=None, 
                     feature_set_version=None, pipeline_url=None, **kwargs):
         self.name = name.upper()
         self.description = description
-        self.pipeline_start_ts = pipeline_start_ts
+        self.pipeline_start_date = pipeline_start_date
         self.pipeline_interval = pipeline_interval
         self.pipeline_id = pipeline_id
         self.pipeline_version = pipeline_version
@@ -14,7 +16,16 @@ class Pipeline:
         args = {k.lower(): kwargs[k] for k in kwargs}
         self.__dict__.update(args)
 
-    def run_pipeline(self, df):
-        for pipe in self.pipes:
+    def run(self):
+        df = self.pipes[0].apply()
+        last = self.pipes[0]
+        for pipe in self.pipes[1:]:
+            if last.language in [PipeLanguage.pyspark, PipeLanguage.sql] and pipe.language == PipeLanguage.python:
+                df = df.toPandas()
+            if last.language == PipeLanguage.python and pipe.language in [PipeLanguage.pyspark, PipeLanguage.sql]:
+                df = pipe._pandas_to_spark(df)
+            if pipe.language == PipeLanguage.sql:
+                df = pipe._df_to_sql(df)
             df = pipe.apply(df)
+            last = pipe
         return df

--- a/splicemachine/features/pipeline.py
+++ b/splicemachine/features/pipeline.py
@@ -1,3 +1,5 @@
+from splicemachine import SpliceMachineException
+from splicemachine.spark.context import ExtPySpliceContext
 from splicemachine.features.constants import PipeLanguage
 
 class Pipeline:
@@ -25,6 +27,9 @@ class Pipeline:
             if last.language == PipeLanguage.python and pipe.language in [PipeLanguage.pyspark, PipeLanguage.sql]:
                 df = pipe._pandas_to_spark(df)
             if pipe.language == PipeLanguage.sql:
+                if isinstance(pipe.splice_ctx, ExtPySpliceContext):
+                    raise SpliceMachineException(f'Error encountered with Pipe {pipe.name}: Cannot execute SQL statements on DataFrames '
+                                                    'when using an ExtPySpliceContext. Please give your pipe a PySpliceContext with pipe.set_splice_ctx()')
                 df = pipe._df_to_sql(df)
             df = pipe.apply(df)
             last = pipe

--- a/splicemachine/features/utils/http_utils.py
+++ b/splicemachine/features/utils/http_utils.py
@@ -57,6 +57,9 @@ class Endpoints:
     BACKFILL_INTERVALS: str = 'backfill-intervals'
     PIPELINE_SQL: str = 'pipeline-sql'
     PIPES: str = 'pipes'
+    PIPELINES: str = 'pipelines'
+    DEPLOY_PIPELINE: str = 'deploy-pipeline'
+    UNDEPLOY_PIPELINE: str = 'undeploy-pipeline'
 
 def make_request(url: str, endpoint: str, method: str, auth: str,
                  params: Optional[Dict[str, Any]] = None,


### PR DESCRIPTION
# Description
Pipelines are an ordered sequence of pipes. Pipelines must start with a Source Pipe. There is a one-to-one mapping of Pipelines to Feature Sets, so when a Pipeline is “deployed” it will have to point to a feature set.

## Motivation and Context
We need to be able to chain Pipes together to form Pipelines.
Fixes [DBAAS-5578](https://splicemachine.atlassian.net/browse/DBAAS-5578)

## Dependencies
[ml-workflow](https://github.com/splicemachine/ml-workflow/pull/194/)

## How Has This Been Tested?
Tested locally on standalone

## Screenshots (if appropriate):

## Changelog Inclusions

### Additions
- New Pipeline object
- Functions for getting, updating, altering, removing, deploying and undeploying pipelines

### Changes

### Fixes

### Deprecated

### Removed

### Breaking Changes
